### PR TITLE
Obtém IP pelo core do Mapas Culturais (header de proxy configurável)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -111,6 +111,15 @@ class Plugin extends \MapasCulturais\Plugin
             }
         });
 
+        $app->hook('entity(<<*>>).remove:after', function () {
+            if ($this instanceof \MapasCulturais\EntityMetadata) {
+                return;
+            }
+
+            $request = new Request();
+            $request->log("{$this} DELETE", []);
+        });
+
         $app->hook('template(panel.user-detail.user-detail--tabs):end', function() {
             $this->part('blame/blame-tab');
         });

--- a/Plugin.php
+++ b/Plugin.php
@@ -71,8 +71,7 @@ class Plugin extends \MapasCulturais\Plugin
         });
         
 
-        $request = new Request;
-        $app->hook('mapasculturais.run:before', function() use($app, $plugin, $request) {
+        $app->hook('mapasculturais.run:before', function() use($app, $plugin) {
             if ($plugin->config['request.enable']) {
                 $request_types = implode('|', $plugin->config['request.types']);
                 $routes = [];
@@ -86,7 +85,15 @@ class Plugin extends \MapasCulturais\Plugin
 
                 $routes = implode(',', $routes);
 
-                $app->hook($routes, function () use($plugin, $request) {
+                $blameRequestHolder = new \stdClass();
+                $blameRequestHolder->request = null;
+
+                $app->hook($routes, function () use($plugin, $blameRequestHolder) {
+                    if ($blameRequestHolder->request === null) {
+                        $blameRequestHolder->request = new Request;
+                    }
+                    $request = $blameRequestHolder->request;
+
                     $request_uri = $_SERVER['REQUEST_URI'];
                     $action = "{$this->method} {$request_uri} ({$this->id}.{$this->action})";
                     
@@ -102,14 +109,6 @@ class Plugin extends \MapasCulturais\Plugin
                     $request->log($action, $metadata);
                 });
             }
-        });
-
-        $app->hook('entity(<<*>>).remove:after', function() use($app, $plugin, $request) {
-            if($this instanceof \MapasCulturais\EntityMetadata) {
-                return;
-            }
-            
-            $request->log("{$this} DELETE", []);
         });
 
         $app->hook('template(panel.user-detail.user-detail--tabs):end', function() {

--- a/Request.php
+++ b/Request.php
@@ -33,7 +33,7 @@ class Request {
         $this->id = $app->getToken(13);
         $this->metadata = (object) $metadata;
         
-        $this->ip = $_SERVER['HTTP_X_REAL_IP'] ?? $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '';
+        $this->ip = $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $_SERVER['HTTP_X_REAL_IP'] ?? $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '';
         $this->userAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
         $this->sessionId = session_id();
         $this->userId = $app->user->id;

--- a/Request.php
+++ b/Request.php
@@ -33,7 +33,8 @@ class Request {
         $this->id = $app->getToken(13);
         $this->metadata = (object) $metadata;
         
-        $this->ip = $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $_SERVER['HTTP_X_REAL_IP'] ?? $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'] ?? '';
+        // Obtendo o IP a partir da propriedade request da PSR-7
+        $this->ip = $app->request->getIp();
         $this->userAgent = $_SERVER['HTTP_USER_AGENT'] ?? '';
         $this->sessionId = session_id();
         $this->userId = $app->user->id;


### PR DESCRIPTION
## Contexto

O core do Mapas Culturais passou a permitir que infra/devops definam **qual cabeçalho HTTP** deve ser usado para obter o IP do cliente atrás de proxy (Cloudflare, nginx, load balancer, etc.), via `PROXY_HEADER` e o ajuste em `Request::getIp()` descrito no [PR #3615 do mapasculturais](https://github.com/mapasculturais/mapasculturais/pull/3615). Com isso, o IP deixa de depender só de `REMOTE_ADDR` e segue a mesma regra do middleware RKA / request PSR-7 no core.

## Cenário

Em **requisições HTTP**, o IP gravado na auditoria (MapasBlame) precisa ser o **mesmo** que o restante da aplicação usa — ou seja, o que `Request::getIp()` do core resolve após o #3615, e não uma leitura paralela de `$_SERVER` no plugin.

## Implementação

- **`MapasBlame\Request`**: o IP vem direto de `$app->request->getIp()` (comentário no código remete à request PSR-7), mantendo o blame alinhado ao core e ao header configurável em `PROXY_HEADER`.
- **`MapasBlame\Plugin`**: o `Request` deixa de ser criado no `_init()` e passa a ser instanciado **na primeira** requisição que dispara os hooks de rota (holder lazy), para só acessar `$app->request` quando o ciclo HTTP já estiver montado. O hook `entity(<<*>>).remove:after` segue registrando delete com `new Request()` dentro do callback, sem depender de instância criada cedo no `_init()`.
