### PR TITLE
Adiciona Suite de Testes para o plugin-MapasBlame

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,15 @@ Sem esse `-f`, a suíte roda normalmente sem o plugin — sem nenhum impacto nos
 | Arquivo | O que valida |
 |---|---|
 | `SmokeTest.php` | Add-on funcionando: plugin ativo, controller `blame` registrado, tabelas `blame_request`/`blame_log` existem e persistem |
-| `Traits/AssertsHooks.php` | Helper `assertHookFired()`/`assertHookNotFired()` — registra um listener temporário para confirmar que um hook foi (ou não foi) disparado, útil quando o efeito do hook não é observável diretamente |
+| `PluginConfigTest.php` | `Plugin::__construct` — defaults de config e o comportamento de union (`+=`) ao passar config customizada |
+| `PluginGetRequestDataTest.php` | `Plugin::getRequestData()` — despacho para `logData.{METHOD}` a partir das propriedades do controller |
+| `PluginRequestHookAssemblyTest.php` | Montagem da string de rotas do hook `mapasculturais.run:before` a partir de `request.types`/`request.routes`/`request.excludeRoutes` |
+| `PluginRemoveHookTest.php` | Hook `entity(<<*>>).remove:after` — dispara para entidades normais, ignora `EntityMetadata`, formato do `action`, sem reuso de holder |
+| `ControllerApiTest.php` | `register()`/`Controller.php` (construtor, `entityClassName`, `usesAPI()`), mapeamento da entidade `Blame` e `API_find` como admin |
+| `PluginAuthHooksTest.php` | Hook `mapas.printJsObject:before` e os gates de autorização de `panel/blame` e da API `blame.<<*>>` |
+| `RequestConstructTest.php` | `Request::__construct` — id, metadata, ip, userAgent, sessionId, userId (logado e guest), browser/os/device, `isNew`, conexão |
+| `RequestPersistenceTest.php` | `Request::save()`/`log()` — as colunas persistidas, o invariante "1ª log() = 2 INSERTs, N logs = 1 request + N logs", edge cases de metadata |
+| `RequestHookEffectTest.php` | Efeito de ponta a ponta do hook de request: gravação via request casada, reuso do holder, formato do `action`, exclusão de `renewLock` |
+| `Doubles/TestablePlugin.php` | Double do `Plugin` com `_init()` no-op (evita registrar hooks globais a cada instância de teste) |
+| `Doubles/TestableRequest.php` | Double do `Request` expondo getters para `isNew`/`conn` (props protegidas) |
+| `Traits/AssertsHooks.php` | Helper `assertHookFired()`/`assertHookNotFired()` — registra um listener para confirmar que um hook foi (ou não foi) disparado, útil quando o efeito do hook não é observável diretamente |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # plugin-MapasBlame
 plugin para registro de logs do sistema
+
+## Como rodar os testes
+
+Os testes do plugin rodam na stack Docker de testes do repositório principal (`tests/docker-compose.yml`), mas **toda a configuração necessária para habilitar o plugin nessa suíte vive aqui dentro**, em `tests/docker-compose.yml` deste plugin, como um único override via `docker compose -f`. Nenhum arquivo do repositório principal (`tests/config.d/`, `config/`) precisa ser editado.
+
+Os comandos abaixo assumem `cwd = tests/` do **repositório principal** (o caminho relativo do override deste plugin depende disso):
+
+```bash
+cd tests   # tests/ do repositório principal, não deste plugin
+
+# build da imagem (necessário na primeira vez ou após mudanças no Dockerfile/composer)
+docker compose build
+
+# roda um teste/método específico, com o plugin MapasBlame habilitado
+docker compose -f docker-compose.yml -f ../src/plugins/MapasBlame/tests/docker-compose.yml \
+  run --rm mapas pu /var/www/tests/MapasBlame/SmokeTest.php
+
+# roda um método específico
+docker compose -f docker-compose.yml -f ../src/plugins/MapasBlame/tests/docker-compose.yml \
+  run --rm mapas pu /var/www/tests/MapasBlame/SmokeTest.php --filter "testPluginIsActive"
+```
+
+Sem esse `-f`, a suíte roda normalmente sem o plugin — sem nenhum impacto nos demais testes.
+
+### Como funciona o override (`tests/docker-compose.yml` deste plugin)
+
+`src/conf/config.php` do core varre, em ordem alfabética, todas as pastas terminadas em `.d/` dentro de `config/` e faz `array_merge` do conteúdo de cada uma. O override deste plugin monta `tests/config.d/` (deste diretório — contém `plugins.php`) como uma pasta nova `zz-mapasblame.d/` dentro de `/var/www/config/` — como `"zz-mapasblame.d"` ordena depois de `"config.d"`, a chave `'plugins'` (inclui `MapasBlame`) sobrescreve a do core.
+
+### Testes existentes (`tests/src/`)
+
+| Arquivo | O que valida |
+|---|---|
+| `SmokeTest.php` | Add-on funcionando: plugin ativo, controller `blame` registrado, tabelas `blame_request`/`blame_log` existem e persistem |
+| `Traits/AssertsHooks.php` | Helper `assertHookFired()`/`assertHookNotFired()` — registra um listener temporário para confirmar que um hook foi (ou não foi) disparado, útil quando o efeito do hook não é observável diretamente |

--- a/tests/config.d/plugins.php
+++ b/tests/config.d/plugins.php
@@ -1,0 +1,16 @@
+<?php
+
+// Habilita o plugin MapasBlame na suíte de testes do repositório principal (tests/docker-compose.yml),
+// sem precisar editar tests/config.d/ do core — montado via tests/docker-compose.yml deste plugin.
+// "zz-mapasblame.d" ordena depois de "config.d" no glob de src/conf/config.php, então o array 'plugins'
+// abaixo substitui por completo o do core (array_merge não funde arrays aninhados) — por isso repete a
+// lista base e só adiciona "MapasBlame" ao final.
+return [
+    'plugins' => [
+        'MultipleLocalAuth',
+        'AdminLoginAsUser',
+        'RecreatePCacheOnLogin',
+        'SpamDetector',
+        'MapasBlame',
+    ]
+];

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  mapas:
+    volumes:
+      # Habilita o plugin MapasBlame na suíte de testes do repositório principal, sem editar
+      # tests/config.d/ do core. "zz-mapasblame.d" ordena depois de "config.d" no glob de
+      # src/conf/config.php, então sobrescreve a chave 'plugins' (config.d/plugins.php deste
+      # diretório) — array_merge não funde arrays aninhados, por isso o arquivo repete a lista
+      # base e só adiciona "MapasBlame" ao final.
+      # Caminho relativo ao cwd esperado do `docker compose` (tests/ do repositório principal).
+      # Monta o DIRETÓRIO (não o arquivo isolado) — bind mount de arquivo único dentro de outro
+      # bind mount (../config:/var/www/config) falha no Docker Desktop/virtiofs (macOS) quando o
+      # subdiretório de destino ainda não existe no host.
+      - ../src/plugins/MapasBlame/tests/config.d:/var/www/config/zz-mapasblame.d
+
+      # Testes do próprio plugin, montados como subpasta de /var/www/tests (mesmo destino de
+      # tests/src do core, mapeado por tests/docker-compose.yml). O autoload PSR-4 'Tests\\' =>
+      # '/var/www/tests' (composer.json) resolve "Tests\MapasBlame\SmokeTest" para
+      # /var/www/tests/MapasBlame/SmokeTest.php, então as classes deste plugin podem usar/estender
+      # Tests\Abstract\TestCase e Tests\Traits\* normalmente.
+      - ../src/plugins/MapasBlame/tests/src:/var/www/tests/MapasBlame

--- a/tests/src/ControllerApiTest.php
+++ b/tests/src/ControllerApiTest.php
@@ -159,4 +159,61 @@ class ControllerApiTest extends TestCase
         // user.{email,profile.{name,avatar}} não vêm — só id e @entityType da relação.
         $this->assertSame(['id' => $user->id, '@entityType' => 'user'], $row['user']);
     }
+
+    /**
+     * db-updates.php:76-97 monta a view com LEFT JOIN blame_request->blame_log — uma
+     * blame_request sem log correspondente (exatamente o que save() sem log() produz,
+     * RequestPersistenceTest::testSaveCalledDirectlyInsertsNothingIntoBlameLog) aparece na
+     * view com as colunas do lado blame_log NULL, incluindo log_id — que é o @ORM\Id da
+     * entidade Blame (Blame.php:20-23).
+     *
+     * Descoberta: a hidratação NÃO falha nem lança exceção com id=null — Doctrine devolve a
+     * linha normalmente (id/action null, o resto das colunas de blame_request presentes).
+     * Comportamento atual observado, não assumido.
+     */
+    function testApiFindHydratesBlameRequestWithoutLogAsNullIdAndAction()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $user = $this->userDirector->createUser();
+
+        $requestId = substr(md5(uniqid('', true)), 0, 13);
+        $conn = $this->app->em->getConnection();
+        $conn->insert('blame_request', [
+            'id' => $requestId,
+            'ip' => '203.0.113.99',
+            'session_id' => str_repeat('c', 32),
+            'user_id' => $user->id,
+            'metadata' => json_encode([]),
+            'user_agent' => 'ControllerApiTest-Agent/1.0',
+            'user_browser_name' => 'ControllerApiTest Browser',
+            'user_browser_version' => '1.0',
+            'user_os' => 'ControllerApiTest OS',
+            'user_device' => 'ControllerApiTest Device',
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+        // Sem INSERT em blame_log de propósito — é o caso órfão do LEFT JOIN.
+
+        $request = new ServerRequest(method: 'GET', uri: '/api/blame/find', queryParams: [
+            '@select' => 'id,requestId,action,ip,userId',
+            'userId' => "EQ({$user->id})",
+        ]);
+
+        $this->app->reset();
+        $this->app->run($request, false);
+
+        $this->assertSame(200, $this->app->response->getStatusCode());
+
+        $body = json_decode((string) $this->app->response->getBody(), true);
+
+        $this->assertCount(1, $body);
+        $row = $body[0];
+
+        $this->assertNull($row['id']);
+        $this->assertNull($row['action']);
+        $this->assertSame($requestId, $row['requestId']);
+        $this->assertSame($user->id, $row['userId']);
+        $this->assertSame('203.0.113.99', $row['ip']);
+    }
 }

--- a/tests/src/ControllerApiTest.php
+++ b/tests/src/ControllerApiTest.php
@@ -29,6 +29,28 @@ class ControllerApiTest extends TestCase
         parent::tearDown();
     }
 
+    /**
+     * Plugin.php:97 lê $_SERVER['REQUEST_URI'] direto — precisa estar montado antes de
+     * qualquer dispatch real ($app->run()) que caia no fallback não-api de erro (ex.: 404),
+     * senão dispara um warning de chave indefinida.
+     */
+    private function withRequestUri(string $uri, callable $callback)
+    {
+        $hadKey = array_key_exists('REQUEST_URI', $_SERVER);
+        $previous = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadKey) {
+                $_SERVER['REQUEST_URI'] = $previous;
+            } else {
+                unset($_SERVER['REQUEST_URI']);
+            }
+        }
+    }
+
     function testConstructorDoesNotThrow()
     {
         $controller = new Controller();
@@ -82,6 +104,35 @@ class ControllerApiTest extends TestCase
 
         $body = json_decode((string) $this->app->response->getBody(), true);
         $this->assertIsArray($body);
+    }
+
+    /**
+     * `Controller::callAction()` (core/Controller.php:305-308) só chama um método real para
+     * dispatch de API se existir `API_{$action}` no controller — para método 'API' a
+     * fallback `ALL_{$action}` é explicitamente pulada (Controller.php:317-319,
+     * "$method !== 'API'"). `MapasBlame\Controller` não declara `API_index` nem qualquer hook
+     * `API(blame.index)` — sem `$call_method` nem `$has_hook`, cai em `$app->pass()`
+     * (Controller.php:349), que lança `Exceptions\NotFound` e vira 404
+     * (RoutesManager.php:88-91). Comportamento observado: a superfície `/api` do controller
+     * `blame` só expõe consulta (`find`, via `ControllerApiV2`) — nenhum verbo de escrita
+     * chega perto de instanciar `Blame` (cujo `__construct` é privado, Blame.php:145) por essa
+     * via. A superfície `/api` do controller `blame`, portanto, só expõe consulta — nenhum
+     * verbo de escrita chega a instanciar `Blame` por esse caminho; ver
+     * `ControllerNonApiSurfaceTest` para a superfície não-api, que expõe escrita de fato.
+     */
+    function testApiPostAsAdminIs404BecauseControllerHasNoApiIndexAction()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $request = new ServerRequest(method: 'POST', uri: '/api/blame');
+
+        $this->withRequestUri('/api/blame', function () use ($request) {
+            $this->app->reset();
+            $this->app->run($request, false);
+        });
+
+        $this->assertSame(404, $this->app->response->getStatusCode());
     }
 
     /**

--- a/tests/src/ControllerApiTest.php
+++ b/tests/src/ControllerApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Laminas\Diactoros\ServerRequest;
+use MapasBlame\Controller;
+use MapasBlame\Entities\Blame;
+use Tests\Abstract\TestCase;
+use Tests\Traits\UserDirector;
+
+class ControllerApiTest extends TestCase
+{
+    use UserDirector;
+
+    // Nota: "$app->controller('blame') resolve para MapasBlame\Controller" já está coberto
+    // por SmokeTest::testBlameControllerIsRegistered — não duplicado aqui.
+
+    function testConstructorDoesNotThrow()
+    {
+        $controller = new Controller();
+
+        $this->assertInstanceOf(Controller::class, $controller);
+    }
+
+    function testEntityClassNameIsExplicit()
+    {
+        $controller = new Controller();
+
+        $this->assertSame('MapasBlame\Entities\Blame', $controller->entityClassName);
+    }
+
+    function testUsesApiReturnsTrue()
+    {
+        $this->assertTrue(Controller::usesAPI());
+    }
+
+    /**
+     * Blame.php:9-11 declara TANTO `@ORM\Entity(readOnly=true)` QUANTO
+     * `@ORM\entity(repositoryClass=...)` (mesma classe, diferindo só no case — PHP resolve
+     * nomes de classe sem diferenciar maiúsculas/minúsculas) — a segunda anotação (sem
+     * readOnly) sobrescreve a primeira, e `readOnly=true` é perdido silenciosamente na
+     * metadata real do Doctrine. É a ÚNICA entidade no codebase combinando os dois desse
+     * jeito — comportamento atual observado, não a intenção do código.
+     */
+    function testBlameEntityReadOnlyAnnotationIsSilentlyOverriddenByRepositoryClassAnnotation()
+    {
+        $metadata = $this->app->em->getClassMetadata(Blame::class);
+
+        $this->assertFalse($metadata->isReadOnly);
+        $this->assertSame('blame', $metadata->getTableName());
+    }
+
+    /**
+     * Cobre também o cenário "API blame.<<*>> como admin → não é barrada pelo gate 403"
+     * (Plugin.php:132-135) — o mesmo hit satisfaz as duas asserções.
+     */
+    function testApiFindAsAdminRespondsWithArray()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $request = new ServerRequest(method: 'GET', uri: '/api/blame/find');
+
+        $this->app->reset();
+        $this->app->run($request, false);
+
+        $this->assertSame(200, $this->app->response->getStatusCode());
+
+        $body = json_decode((string) $this->app->response->getBody(), true);
+        $this->assertIsArray($body);
+    }
+}

--- a/tests/src/ControllerApiTest.php
+++ b/tests/src/ControllerApiTest.php
@@ -6,14 +6,28 @@ use Laminas\Diactoros\ServerRequest;
 use MapasBlame\Controller;
 use MapasBlame\Entities\Blame;
 use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Traits\RestoresHookRegistry;
 use Tests\Traits\UserDirector;
 
 class ControllerApiTest extends TestCase
 {
+    use RestoresHookRegistry;
     use UserDirector;
 
     // Nota: "$app->controller('blame') resolve para MapasBlame\Controller" já está coberto
     // por SmokeTest::testBlameControllerIsRegistered — não duplicado aqui.
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotHookRegistry();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreHookRegistry();
+        parent::tearDown();
+    }
 
     function testConstructorDoesNotThrow()
     {

--- a/tests/src/ControllerApiTest.php
+++ b/tests/src/ControllerApiTest.php
@@ -83,4 +83,80 @@ class ControllerApiTest extends TestCase
         $body = json_decode((string) $this->app->response->getBody(), true);
         $this->assertIsArray($body);
     }
+
+    /**
+     * Insere direto via conexão (mesmo padrão do SmokeTest) 1 par blame_request+blame_log —
+     * db-updates.php:76-97 mapeia essas colunas na view "blame" que a entidade Blame lê.
+     */
+    private function seedBlameRequestAndLog(int $userId, string $action): string
+    {
+        $requestId = substr(md5(uniqid('', true)), 0, 13);
+        $conn = $this->app->em->getConnection();
+
+        $conn->insert('blame_request', [
+            'id' => $requestId,
+            'ip' => '203.0.113.10',
+            'session_id' => str_repeat('a', 32),
+            'user_id' => $userId,
+            'metadata' => json_encode(['URL' => [], 'GET' => []]),
+            'user_agent' => 'ControllerApiTest-Agent/1.0',
+            'user_browser_name' => 'ControllerApiTest Browser',
+            'user_browser_version' => '1.0',
+            'user_os' => 'ControllerApiTest OS',
+            'user_device' => 'ControllerApiTest Device',
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+
+        $conn->insert('blame_log', [
+            'request_id' => $requestId,
+            'action' => $action,
+            'metadata' => json_encode([]),
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+
+        return $requestId;
+    }
+
+    /**
+     * A entidade Blame nunca era exercitada com dados reais na suíte — este teste semeia uma
+     * linha real e confirma a hidratação com o mesmo @select e filtro de userId que
+     * components/blame-table/script.js:52 usa verbatim.
+     *
+     * Descoberta: apesar do front-end pedir `user.{email,profile.{name,avatar}}`, a API
+     * devolve só `{id, @entityType}` para a relação user — os subcampos pedidos são
+     * ignorados. Comportamento atual observado (a tabela do painel provavelmente exibe
+     * célula vazia onde esperaria email/nome/avatar do usuário) — não é escopo desta suíte
+     * investigar a causa em ApiQuery::_preCreateSelectSubquery, só travar o que é.
+     */
+    function testApiFindReturnsHydratedRowMatchingFrontendSelect()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        $user = $this->userDirector->createUser();
+        $requestId = $this->seedBlameRequestAndLog($user->id, 'GET /site/index (site.index)');
+
+        $request = new ServerRequest(method: 'GET', uri: '/api/blame/find', queryParams: [
+            '@select' => 'id,sessionId,requestId,requestTimestamp,action,logTimestamp,userBrowserName,userBrowserVersion,ip,userId,userOS,userDevice,user.{email,profile.{name,avatar}}',
+            'userId' => "EQ({$user->id})",
+        ]);
+
+        $this->app->reset();
+        $this->app->run($request, false);
+
+        $this->assertSame(200, $this->app->response->getStatusCode());
+
+        $body = json_decode((string) $this->app->response->getBody(), true);
+
+        $this->assertCount(1, $body, 'Deveria retornar exatamente a linha semeada para este userId');
+        $row = $body[0];
+
+        $this->assertSame($requestId, $row['requestId']);
+        $this->assertSame($user->id, $row['userId']);
+        $this->assertSame('GET /site/index (site.index)', $row['action']);
+        $this->assertSame('203.0.113.10', $row['ip']);
+        // Comportamento observado (ver docblock do teste): os subcampos pedidos em
+        // user.{email,profile.{name,avatar}} não vêm — só id e @entityType da relação.
+        $this->assertSame(['id' => $user->id, '@entityType' => 'user'], $row['user']);
+    }
 }

--- a/tests/src/ControllerNonApiSurfaceTest.php
+++ b/tests/src/ControllerNonApiSurfaceTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\MapasBlame;
 
+use MapasBlame\Entities\Blame;
+use MapasCulturais\Exceptions\PermissionDenied;
 use Tests\Abstract\TestCase;
 use Tests\MapasBlame\Traits\RestoresHookRegistry;
 use Tests\Traits\RequestFactory;
@@ -137,5 +139,67 @@ class ControllerNonApiSurfaceTest extends TestCase
         $body = json_decode((string) $this->app->response->getBody(), true);
         $this->assertSame($logId, $body['id']);
         $this->assertSame($other->id, $body['user']['id']);
+    }
+
+    // ===== DELETE /blame/single/{id} =====
+
+    function testDeleteSingleAsNonAuthorNonAdminIsForbidden()
+    {
+        $user = $this->userDirector->createUser();
+        $other = $this->userDirector->createUser();
+        $logId = $this->seedBlameLogId($other->id);
+        $this->login($user);
+
+        $request = $this->requestFactory->DELETE('blame', 'single', [$logId]);
+
+        $this->withRequestUri("/blame/single/{$logId}", function () use ($request) {
+            $this->assertStatus403($request);
+        });
+    }
+
+    /**
+     * NÃO despachamos um DELETE real como autor/admin aqui — ver docblock da classe e a nota
+     * abaixo. Este teste caracteriza só a CHECAGEM DE PERMISSÃO (Entity::checkPermission,
+     * chamada direta, sem passar por Controller::DELETE_single), que é o que determina se a
+     * remoção sequer chega a ser tentada.
+     *
+     * Descoberta: DELETE_single() (core/Traits/ControllerEntityActions.php:376-386) chama
+     * $entity->delete(true) sem NENHUMA checagem própria — delega inteiramente a
+     * Entity::canUserRemove(), que concede permissão tanto para admin quanto para
+     * getOwnerUser()->id == $user->id. Como Blame tem uma relação real $user
+     * (Blame.php:41-49), Entity::getOwnerUser() (Entity.php:328-333, "isset($this->user)")
+     * retorna essa relação — ou seja, QUALQUER usuário autenticado passa na checagem de
+     * permissão de remoção para uma linha de auditoria que registrou uma ação SUA PRÓPRIA,
+     * não só admin.
+     *
+     * Verificado manualmente (fora da suíte automatizada, pelo risco abaixo) que a remoção
+     * de fato tentada — tanto pelo autor quanto por um admin — falha no Postgres com
+     * "cannot delete from view "blame": Views that do not select from a single table or view
+     * are not automatically updatable" (SQLSTATE 55000), e essa falha FECHA o EntityManager
+     * do Doctrine para o resto do processo PHP — como a suíte roda sem isolamento de
+     * processo, qualquer arquivo de teste que rodasse depois deste na mesma execução
+     * quebraria com "EntityManager is closed". Por isso a suíte automatizada trava só a
+     * checagem de permissão (que não toca o banco além de um SELECT), não a tentativa real
+     * de DELETE.
+     */
+    function testDeleteSingleCheckPermissionPassesForAuthorOfTheLoggedActionEvenNotAdmin()
+    {
+        $user = $this->userDirector->createUser();
+        $logId = $this->seedBlameLogId($user->id);
+        $this->login($user);
+
+        $blame = $this->app->repo(Blame::class)->find($logId);
+
+        $threw = false;
+        try {
+            $blame->checkPermission('remove');
+        } catch (PermissionDenied $e) {
+            $threw = true;
+        }
+
+        $this->assertFalse(
+            $threw,
+            'O autor da ação logada (blame_request.user_id) deveria passar na checagem de permissão de remoção, mesmo não sendo admin'
+        );
     }
 }

--- a/tests/src/ControllerNonApiSurfaceTest.php
+++ b/tests/src/ControllerNonApiSurfaceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Traits\RestoresHookRegistry;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+/**
+ * O gate de autorização do plugin (Plugin.php:132-136) só cobre `API(blame.<<*>>):before` —
+ * rotas /api. Mas `MapasBlame\Controller` herda `EntityController` completo (Controller.php:6
+ * — `ControllerEntity`, `ControllerEntityActions`, `ControllerEntityViews`), que expõe rotas
+ * NÃO-api como `GET /blame/single/{id}` e `DELETE /blame/single/{id}` — o core só dispara
+ * hooks `API(...)` para rotas /api (core/Controller.php:305-308), então essas rotas nunca
+ * passam pelo gate do plugin. Nunca considerado nem documentado antes desta revisão.
+ */
+class ControllerNonApiSurfaceTest extends TestCase
+{
+    use RequestFactory;
+    use RestoresHookRegistry;
+    use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotHookRegistry();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreHookRegistry();
+        parent::tearDown();
+    }
+
+    /**
+     * Plugin.php:97 lê $_SERVER['REQUEST_URI'] direto — precisa estar montado antes de
+     * qualquer dispatch real ($app->run()), senão dispara um warning de chave indefinida.
+     */
+    private function withRequestUri(string $uri, callable $callback)
+    {
+        $hadKey = array_key_exists('REQUEST_URI', $_SERVER);
+        $previous = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadKey) {
+                $_SERVER['REQUEST_URI'] = $previous;
+            } else {
+                unset($_SERVER['REQUEST_URI']);
+            }
+        }
+    }
+
+    private function seedBlameLogId(int $userId): int
+    {
+        $requestId = substr(md5(uniqid('', true)), 0, 13);
+        $conn = $this->app->em->getConnection();
+
+        $conn->insert('blame_request', [
+            'id' => $requestId,
+            'ip' => '203.0.113.50',
+            'session_id' => str_repeat('d', 32),
+            'user_id' => $userId,
+            'metadata' => json_encode([]),
+            'user_agent' => 'ControllerNonApiSurfaceTest',
+            'user_browser_name' => 'ControllerNonApiSurfaceTest',
+            'user_browser_version' => '1.0',
+            'user_os' => 'ControllerNonApiSurfaceTest',
+            'user_device' => 'ControllerNonApiSurfaceTest',
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+        $conn->insert('blame_log', [
+            'request_id' => $requestId,
+            'action' => 'ACTION',
+            'metadata' => json_encode([]),
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+
+        return (int) $this->app->em->getConnection()->fetchScalar(
+            'SELECT id FROM blame_log WHERE request_id = ?',
+            [$requestId]
+        );
+    }
+
+    // ===== GET /blame/single/{id} =====
+
+    function testGetSingleAsGuestIs404()
+    {
+        $user = $this->userDirector->createUser();
+        $logId = $this->seedBlameLogId($user->id);
+
+        $request = $this->requestFactory->GET('blame', 'single', [$logId], ajax: true);
+
+        $this->withRequestUri("/blame/single/{$logId}", function () use ($request) {
+            $this->assertStatus404($request);
+        });
+    }
+
+    /**
+     * canUserView (Entity.php, herdado — Blame não sobrescreve) não usa getOwnerUser(): cai
+     * em canUser('@control'), que checa $this->owner (indefinido em Blame, só existe $user) —
+     * nenhum branch de canUser_control passa para um não-admin. Ser "o autor da ação logada"
+     * (blame_request.user_id) não concede view. Comportamento observado, não assumido.
+     */
+    function testGetSingleAsAuthorOfTheLoggedActionIs404()
+    {
+        $user = $this->userDirector->createUser();
+        $logId = $this->seedBlameLogId($user->id);
+        $this->login($user);
+
+        $request = $this->requestFactory->GET('blame', 'single', [$logId], ajax: true);
+
+        $this->withRequestUri("/blame/single/{$logId}", function () use ($request) {
+            $this->assertStatus404($request);
+        });
+    }
+
+    function testGetSingleAsAdminRespondsWithEntityJson()
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $other = $this->userDirector->createUser();
+        $logId = $this->seedBlameLogId($other->id);
+        $this->login($admin);
+
+        $request = $this->requestFactory->GET('blame', 'single', [$logId], ajax: true);
+
+        $this->withRequestUri("/blame/single/{$logId}", function () use ($request) {
+            $this->app->reset();
+            $this->app->run($request, false);
+        });
+
+        $this->assertSame(200, $this->app->response->getStatusCode());
+
+        $body = json_decode((string) $this->app->response->getBody(), true);
+        $this->assertSame($logId, $body['id']);
+        $this->assertSame($other->id, $body['user']['id']);
+    }
+}

--- a/tests/src/Doubles/TestablePlugin.php
+++ b/tests/src/Doubles/TestablePlugin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\MapasBlame\Doubles;
+
+use MapasBlame\Plugin;
+
+/**
+ * Sobrescreve _init() para não-operação: MapasCulturais\Module::__construct chama _init()
+ * direto no construtor, e o _init() real do Plugin registra hooks globais no App
+ * (mapasculturais.run:before, entity(<<*>>).remove:after, etc.) — instanciar o Plugin real
+ * repetidamente nos testes acumularia esses hooks a cada instância, sem isolamento de processo.
+ */
+class TestablePlugin extends Plugin
+{
+    function _init()
+    {
+    }
+}

--- a/tests/src/Doubles/TestablePlugin.php
+++ b/tests/src/Doubles/TestablePlugin.php
@@ -15,4 +15,25 @@ class TestablePlugin extends Plugin
     function _init()
     {
     }
+
+    /**
+     * Espelha a montagem da string de rotas feita em Plugin.php:76-86, hoje inline dentro
+     * da closure de `mapasculturais.run:before` (registrada apenas quando _init() roda de
+     * verdade). Mesma expressão, fora da closure — se essa lógica mudar em Plugin.php, este
+     * método precisa ser atualizado manualmente para não dessincronizar.
+     */
+    function buildRequestHookRoutes(): string
+    {
+        $request_types = implode('|', $this->config['request.types']);
+        $routes = [];
+
+        foreach ($this->config['request.routes'] as $route) {
+            $routes[] = "<<$request_types>>($route):before";
+        }
+        foreach ($this->config['request.excludeRoutes'] as $route) {
+            $routes[] = "-<<*>>($route):before";
+        }
+
+        return implode(',', $routes);
+    }
 }

--- a/tests/src/Doubles/TestableRequest.php
+++ b/tests/src/Doubles/TestableRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\MapasBlame\Doubles;
+
+use MapasBlame\Request;
+
+/**
+ * Expõe getters para as props protegidas de Request ($isNew, $conn) sem alterar nenhum
+ * comportamento — nunca sobrescreve um método, só adiciona acesso de leitura.
+ */
+class TestableRequest extends Request
+{
+    function isNew(): bool
+    {
+        return $this->isNew;
+    }
+
+    function conn(): object
+    {
+        return $this->conn;
+    }
+}

--- a/tests/src/PluginAuthHooksTest.php
+++ b/tests/src/PluginAuthHooksTest.php
@@ -128,6 +128,16 @@ class PluginAuthHooksTest extends TestCase
         });
     }
 
+    function testApiBlameAsGuestIsForbidden()
+    {
+        // setUp() já faz logout(); usuário atual é GuestUser.
+        $request = new ServerRequest(method: 'GET', uri: '/api/blame/find');
+
+        $this->withRequestUri('/api/blame/find', function () use ($request) {
+            $this->assertStatus403($request);
+        });
+    }
+
     // Nota: "API blame.<<*>> como admin → não é barrada pelo gate 403" já está coberto por
     // ControllerApiTest::testApiFindAsAdminRespondsWithArray — não duplicado aqui.
 }

--- a/tests/src/PluginAuthHooksTest.php
+++ b/tests/src/PluginAuthHooksTest.php
@@ -13,10 +13,13 @@ class PluginAuthHooksTest extends TestCase
     use RestoresHookRegistry;
     use UserDirector;
 
+    private $viewControllerSnapshot;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->snapshotHookRegistry();
+        $this->viewControllerSnapshot = $this->app->view->controller;
     }
 
     protected function tearDown(): void
@@ -32,6 +35,11 @@ class PluginAuthHooksTest extends TestCase
         // legítimos de outros módulos/plugins (LGPD, MultipleLocalAuth, ProfileCompletion)
         // que também casam o nome 'GET(panel.blame):before'.
         $this->restoreHookRegistry();
+
+        // testPrintJsObjectPopulatesEntitiesDescriptionForBlame atribui $app->view->controller
+        // diretamente (Theme.php:164-169 lê essa propriedade) — sem restaurar aqui, o valor
+        // vaza para outros arquivos que rodam depois no mesmo processo (sem isolamento).
+        $this->app->view->controller = $this->viewControllerSnapshot;
 
         parent::tearDown();
     }

--- a/tests/src/PluginAuthHooksTest.php
+++ b/tests/src/PluginAuthHooksTest.php
@@ -5,22 +5,33 @@ namespace Tests\MapasBlame;
 use Laminas\Diactoros\ServerRequest;
 use MapasBlame\Entities\Blame;
 use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Traits\RestoresHookRegistry;
 use Tests\Traits\UserDirector;
 
 class PluginAuthHooksTest extends TestCase
 {
+    use RestoresHookRegistry;
     use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotHookRegistry();
+    }
 
     protected function tearDown(): void
     {
         // Cada $app->run() contra uma rota casada (panel/blame) faz o listener de
         // mapasculturais.run:before de Plugin.php:74 registrar MAIS UM listener permanente
         // no padrão de rotas — o closure não é idempotente, os listeners antigos nunca são
-        // removidos. Sem limpar aqui, esses listeners sobrevivem além deste arquivo e, ao
+        // removidos. Sem restaurar aqui, esses listeners sobrevivem além deste arquivo e, ao
         // disparar de novo em outro arquivo, tentam reusar um Request cujo blame_request já
         // foi desfeito pelo rollback deste teste — violação de FK que aborta a transação do
-        // teste seguinte.
-        $this->app->clearHooks('GET(panel.blame):before');
+        // teste seguinte. restoreHookRegistry() (ao contrário de clearHooks(), usado aqui
+        // antes) remove só o que foi registrado durante este teste, sem atingir listeners
+        // legítimos de outros módulos/plugins (LGPD, MultipleLocalAuth, ProfileCompletion)
+        // que também casam o nome 'GET(panel.blame):before'.
+        $this->restoreHookRegistry();
 
         parent::tearDown();
     }

--- a/tests/src/PluginAuthHooksTest.php
+++ b/tests/src/PluginAuthHooksTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Laminas\Diactoros\ServerRequest;
+use MapasBlame\Entities\Blame;
+use Tests\Abstract\TestCase;
+use Tests\Traits\UserDirector;
+
+class PluginAuthHooksTest extends TestCase
+{
+    use UserDirector;
+
+    protected function tearDown(): void
+    {
+        // Cada $app->run() contra uma rota casada (panel/blame) faz o listener de
+        // mapasculturais.run:before de Plugin.php:74 registrar MAIS UM listener permanente
+        // no padrão de rotas — o closure não é idempotente, os listeners antigos nunca são
+        // removidos. Sem limpar aqui, esses listeners sobrevivem além deste arquivo e, ao
+        // disparar de novo em outro arquivo, tentam reusar um Request cujo blame_request já
+        // foi desfeito pelo rollback deste teste — violação de FK que aborta a transação do
+        // teste seguinte.
+        $this->app->clearHooks('GET(panel.blame):before');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Plugin.php:97 lê $_SERVER['REQUEST_URI'] direto — precisa estar montado antes de
+     * qualquer dispatch real ($app->run()), senão dispara um warning de chave indefinida.
+     */
+    private function withRequestUri(string $uri, callable $callback)
+    {
+        $hadKey = array_key_exists('REQUEST_URI', $_SERVER);
+        $previous = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadKey) {
+                $_SERVER['REQUEST_URI'] = $previous;
+            } else {
+                unset($_SERVER['REQUEST_URI']);
+            }
+        }
+    }
+
+    function testPrintJsObjectPopulatesEntitiesDescriptionForBlame()
+    {
+        $theme = $this->app->view;
+        // Theme.php:164-169 também escuta mapas.printJsObject:before e lê
+        // $app->view->controller->id/action/urlData — sem um controller real montado
+        // (nenhum dispatch aconteceu neste teste), isso dispararia warnings de
+        // "read property on null".
+        $theme->controller = $this->app->controller('site');
+
+        $this->app->applyHookBoundTo($theme, 'mapas.printJsObject:before');
+
+        $this->assertSame(
+            Blame::getPropertiesMetadata(),
+            $theme->jsObject['EntitiesDescription']['blame']
+        );
+    }
+
+    function testPanelBlameRequiresAuthenticationForGuest()
+    {
+        $request = new ServerRequest(
+            method: 'GET',
+            uri: '/panel/blame',
+            headers: ['X-Requested-With' => 'XMLHttpRequest']
+        );
+
+        $this->withRequestUri('/panel/blame', function () use ($request) {
+            $this->assertStatus401($request);
+        });
+    }
+
+    /**
+     * Descoberta: nenhum tema no repositório (BaseV1, BaseV2, Funarte, MapaMinC, Pnab,
+     * Subsite) tem um arquivo de view "panel/blame-system" — hitar esta rota autenticado
+     * produz hoje um erro 500 ("Template panel/blame-system.php not found"), não um render
+     * bem-sucedido. O gate de autenticação (Plugin.php:127-129) não é o que bloqueia — o
+     * usuário passa por requireAuthentication() normalmente; é a chamada a
+     * $this->render('blame-system', []) logo em seguida que falha. Comportamento atual
+     * travado como está, não a intenção original do código.
+     */
+    function testPanelBlameAuthenticatedPassesAuthenticationButTemplateIsMissing()
+    {
+        $user = $this->userDirector->createUser();
+        $this->login($user);
+
+        $request = new ServerRequest(method: 'GET', uri: '/panel/blame');
+
+        $this->withRequestUri('/panel/blame', function () use ($request) {
+            $this->assertHttpStatusCode($request, 500);
+        });
+    }
+
+    function testApiBlameAsNonAdminIsForbidden()
+    {
+        $user = $this->userDirector->createUser();
+        $this->login($user);
+
+        $request = new ServerRequest(method: 'GET', uri: '/api/blame/find');
+
+        $this->withRequestUri('/api/blame/find', function () use ($request) {
+            $this->assertStatus403($request);
+        });
+    }
+
+    // Nota: "API blame.<<*>> como admin → não é barrada pelo gate 403" já está coberto por
+    // ControllerApiTest::testApiFindAsAdminRespondsWithArray — não duplicado aqui.
+}

--- a/tests/src/PluginConfigTest.php
+++ b/tests/src/PluginConfigTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Doubles\TestablePlugin;
+
+class PluginConfigTest extends TestCase
+{
+    // ===== Defaults (sem config) =====
+
+    function testDefaultRequestTypesIncludesAllHttpVerbs()
+    {
+        $plugin = new TestablePlugin();
+
+        $this->assertSame(['GET', 'DELETE', 'PATCH', 'POST', 'PUT'], $plugin->config['request.types']);
+    }
+
+    function testDefaultRequestEnableIsTrue()
+    {
+        $plugin = new TestablePlugin();
+
+        $this->assertTrue($plugin->config['request.enable']);
+    }
+
+    function testDefaultRequestRoutesIsWildcard()
+    {
+        $plugin = new TestablePlugin();
+
+        $this->assertSame(['<<*>>'], $plugin->config['request.routes']);
+    }
+
+    function testDefaultRequestExcludeRoutesIsRenewLock()
+    {
+        $plugin = new TestablePlugin();
+
+        $this->assertSame(['<<*>>.renewLock'], $plugin->config['request.excludeRoutes']);
+    }
+
+    function testDefaultLogDataUrlReturnsDataUnchanged()
+    {
+        $plugin = new TestablePlugin();
+
+        $data = ['foo' => 'bar'];
+        $this->assertSame($data, $plugin->config['request.logData.URL']($data));
+    }
+
+    function testDefaultLogDataGetReturnsDataUnchanged()
+    {
+        $plugin = new TestablePlugin();
+
+        $data = ['foo' => 'bar'];
+        $this->assertSame($data, $plugin->config['request.logData.GET']($data));
+    }
+
+    function testDefaultLogDataWriteVerbsReturnEmptyArray()
+    {
+        $plugin = new TestablePlugin();
+
+        foreach (['POST', 'PUT', 'PATCH', 'DELETE'] as $method) {
+            $this->assertSame(
+                [],
+                $plugin->config["request.logData.{$method}"](['foo' => 'bar']),
+                "request.logData.{$method} deveria retornar []"
+            );
+        }
+    }
+
+    // ===== Config passado no construtor (union `+=`) =====
+
+    function testConfigRequestTypesOverridesDefault()
+    {
+        $plugin = new TestablePlugin(['request.types' => ['POST', 'PUT']]);
+
+        $this->assertSame(['POST', 'PUT'], $plugin->config['request.types']);
+    }
+
+    function testConfigRequestEnableFalseIsPreserved()
+    {
+        $plugin = new TestablePlugin(['request.enable' => false]);
+
+        $this->assertFalse($plugin->config['request.enable']);
+    }
+
+    function testConfigExtraKeyNotPresentInDefaultsIsPreserved()
+    {
+        $plugin = new TestablePlugin(['some.extra.key' => 'valor']);
+
+        $this->assertSame('valor', $plugin->config['some.extra.key']);
+    }
+
+    function testConfigLogDataPostOverridesDefault()
+    {
+        $custom = function ($data) {
+            return ['custom' => true];
+        };
+
+        $plugin = new TestablePlugin(['request.logData.POST' => $custom]);
+
+        $this->assertSame(['custom' => true], $plugin->config['request.logData.POST']([]));
+    }
+}

--- a/tests/src/PluginGetRequestDataTest.php
+++ b/tests/src/PluginGetRequestDataTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Doubles\TestablePlugin;
+
+class PluginGetRequestDataTest extends TestCase
+{
+    function testGetRequestDataUrlReadsUrlDataAndAppliesLogData()
+    {
+        $plugin = new TestablePlugin();
+
+        $controller = new \stdClass();
+        $controller->urlData = ['id' => 42];
+
+        $this->assertSame(['id' => 42], $plugin->getRequestData($controller, 'URL'));
+    }
+
+    function testGetRequestDataGetReadsGetDataAndAppliesLogData()
+    {
+        $plugin = new TestablePlugin();
+
+        $controller = new \stdClass();
+        $controller->getData = ['page' => 2];
+
+        $this->assertSame(['page' => 2], $plugin->getRequestData($controller, 'GET'));
+    }
+
+    function testGetRequestDataPostReadsPostDataAndAppliesDefaultLogData()
+    {
+        $plugin = new TestablePlugin();
+
+        $controller = new \stdClass();
+        $controller->postData = ['password' => 'secreta'];
+
+        $this->assertSame([], $plugin->getRequestData($controller, 'POST'));
+    }
+
+    function testGetRequestDataPropertyNameIsDerivedFromLowercaseMethod()
+    {
+        // Sobrescreve logData.PATCH com identidade para expor o valor lido de $controller,
+        // provando que a propriedade acessada foi "patchData" (strtolower('PATCH') . 'Data').
+        $identity = function ($data) {
+            return $data;
+        };
+        $plugin = new TestablePlugin(['request.logData.PATCH' => $identity]);
+
+        $controller = new \stdClass();
+        $controller->patchData = ['field' => 'valor'];
+
+        $this->assertSame(['field' => 'valor'], $plugin->getRequestData($controller, 'PATCH'));
+    }
+}

--- a/tests/src/PluginRemoveHookTest.php
+++ b/tests/src/PluginRemoveHookTest.php
@@ -96,6 +96,9 @@ class PluginRemoveHookTest extends TestCase
         $logs = $this->fetchBlameLogs($new[0]);
         $this->assertCount(1, $logs, 'A remoção deveria gerar exatamente 1 blame_log');
         $this->assertStringEndsWith(' DELETE', $logs[0]['action']);
+        // Plugin.php:119-120 chama $request->log("{$this} DELETE", []) — metadata é sempre
+        // o array vazio literal, nunca dados da entidade removida.
+        $this->assertSame('[]', $logs[0]['metadata']);
     }
 
     function testActionUsesEntityToStringFollowedByDelete()

--- a/tests/src/PluginRemoveHookTest.php
+++ b/tests/src/PluginRemoveHookTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use MapasCulturais\Entities\Agent;
+use MapasCulturais\Request as CoreRequest;
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Traits\AssertsHooks;
+use Tests\Traits\AgentDirector;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class PluginRemoveHookTest extends TestCase
+{
+    use AssertsHooks;
+    use AgentDirector;
+    use RequestFactory;
+    use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // MapasBlame\Request::__construct lê $app->request->getIp(), e $app->request
+        // é null por padrão em teste — Plugin.php:119 cria um `new Request()` a cada
+        // remoção, então precisa estar montado antes de qualquer teste deste arquivo.
+        $psr7 = $this->requestFactory->GET('site', 'index');
+        $this->app->request = new CoreRequest($psr7, 'site', 'index', []);
+    }
+
+    private function snapshotBlameRequestIds(): array
+    {
+        return $this->app->em->getConnection()->fetchColumn('SELECT id FROM blame_request');
+    }
+
+    private function fetchBlameLogs(string $requestId): array
+    {
+        return $this->app->em->getConnection()->fetchAll(
+            'SELECT * FROM blame_log WHERE request_id = ? ORDER BY id',
+            [$requestId]
+        );
+    }
+
+    private function newBlameRequestIds(array $before): array
+    {
+        $after = $this->snapshotBlameRequestIds();
+
+        return array_values(array_diff($after, $before));
+    }
+
+    /**
+     * Agent usa a trait EntitySoftDelete, que sobrescreve delete() para um soft-delete
+     * (muda `status` para TRASH) — a remoção física via Doctrine (que dispara o postRemove
+     * lifecycle callback e, por consequência, `entity(<<*>>).remove:after`) só acontece
+     * através de destroy(), que chama parent::delete() (Entity::delete() real). Além disso,
+     * Agent::canUserDestroy() (Agent.php:525-531) exige superAdmin — por isso o usuário
+     * logado nos testes deste arquivo é criado com esse papel.
+     */
+    private function destroyAgent($agent): void
+    {
+        $agent->destroy(true);
+    }
+
+    function testRemovingNormalEntityFiresTheRemoveHook()
+    {
+        $user = $this->userDirector->createUser('superAdmin');
+        $this->login($user);
+        $agent = $this->agentDirector->createIndividual($user);
+
+        $this->assertHookFired('entity(Agent).remove:after', function () use ($agent) {
+            $this->destroyAgent($agent);
+        });
+    }
+
+    function testRemovingNormalEntityInsertsOneBlameRequestAndOneBlameLogEndingInDelete()
+    {
+        $user = $this->userDirector->createUser('superAdmin');
+        $this->login($user);
+        $agent = $this->agentDirector->createIndividual($user);
+
+        $before = $this->snapshotBlameRequestIds();
+        $this->destroyAgent($agent);
+        $new = $this->newBlameRequestIds($before);
+
+        $this->assertCount(1, $new, 'Remover uma entidade normal deveria criar exatamente 1 blame_request');
+
+        $logs = $this->fetchBlameLogs($new[0]);
+        $this->assertCount(1, $logs, 'A remoção deveria gerar exatamente 1 blame_log');
+        $this->assertStringEndsWith(' DELETE', $logs[0]['action']);
+    }
+
+    function testActionUsesEntityToStringFollowedByDelete()
+    {
+        $user = $this->userDirector->createUser('superAdmin');
+        $this->login($user);
+        $agent = $this->agentDirector->createIndividual($user);
+        // Doctrine zera o id em memória antes de disparar o postRemove lifecycle callback
+        // (é isso que dispara nosso hook) — "{$this}" nesse momento já não tem mais o id,
+        // vira "ClassName:" (vazio), não "ClassName:123". Comportamento atual observado.
+        $expectedAction = get_class($agent) . ': DELETE';
+
+        $before = $this->snapshotBlameRequestIds();
+        $this->destroyAgent($agent);
+        $new = $this->newBlameRequestIds($before);
+
+        $logs = $this->fetchBlameLogs($new[0]);
+        $this->assertSame($expectedAction, $logs[0]['action']);
+    }
+
+    function testRemovingEntityMetadataDoesNotLog()
+    {
+        $user = $this->userDirector->createUser('superAdmin');
+        $this->login($user);
+        $agent = $this->agentDirector->createIndividual($user);
+
+        // 'sentNotification' é registrada como metadata do Agent pela classe base Theme
+        // (Theme.php:158-160, hook 'app.register') — disponível independente do tema ativo.
+        $agent->sentNotification = true;
+        $agent->saveMetadata();
+
+        $agentMeta = $this->app->repo('AgentMeta')->findOneBy(['owner' => $agent, 'key' => 'sentNotification']);
+        $this->assertNotNull($agentMeta, 'saveMetadata() deveria ter persistido um AgentMeta "sentNotification"');
+
+        $before = $this->snapshotBlameRequestIds();
+
+        // Confirma que o hook REALMENTE dispara para AgentMeta (senão o assertCount(0, ...)
+        // abaixo passaria de qualquer forma, mesmo que o hook nunca alcançasse nosso closure
+        // — o que provaria uma coisa bem diferente do "return" do instanceof em Plugin.php:116).
+        $this->assertHookFired('entity(AgentMeta).remove:after', function () use ($agentMeta) {
+            $this->app->em->remove($agentMeta);
+            $this->app->em->flush();
+        }, 'Remover um AgentMeta deveria disparar entity(AgentMeta).remove:after (para então ser ignorado pelo instanceof)');
+
+        $new = $this->newBlameRequestIds($before);
+        $this->assertCount(0, $new, 'Remover uma instância de EntityMetadata não deveria gerar um blame_request');
+    }
+
+    function testEachRemovalCreatesItsOwnBlameRequest()
+    {
+        // Sem login: nada aqui passa por checkPermission — o disparo do hook é manual
+        // (abaixo), não via destroy()/Doctrine, então não há checagem de permissão a
+        // satisfazer.
+        $user = $this->userDirector->createUser();
+
+        // Duas instâncias de Agent NÃO persistidas, só para servir de $this ao closure —
+        // o que este cenário precisa provar é que Plugin.php:119 (`$request = new Request()`,
+        // sem holder) cria um Request novo a cada disparo, não que a remoção física via
+        // Doctrine funciona (já coberto pelos testes acima). Disparar o hook diretamente evita
+        // o pipeline completo de remoção (revisão + relações de taxonomia) de dois agentes
+        // reais em sequência, irrelevante para o que está sendo travado aqui.
+        $agentA = new Agent($user);
+        $agentB = new Agent($user);
+
+        $before = $this->snapshotBlameRequestIds();
+        $this->app->applyHookBoundTo($agentA, 'entity(Agent).remove:after', []);
+        $this->app->applyHookBoundTo($agentB, 'entity(Agent).remove:after', []);
+        $new = $this->newBlameRequestIds($before);
+
+        $this->assertCount(2, $new, 'Cada remoção deveria criar seu próprio blame_request — sem reuso de holder');
+    }
+}

--- a/tests/src/PluginRemoveHookTest.php
+++ b/tests/src/PluginRemoveHookTest.php
@@ -6,6 +6,7 @@ use MapasCulturais\Entities\Agent;
 use MapasCulturais\Request as CoreRequest;
 use Tests\Abstract\TestCase;
 use Tests\MapasBlame\Traits\AssertsHooks;
+use Tests\MapasBlame\Traits\RestoresAppRequest;
 use Tests\Traits\AgentDirector;
 use Tests\Traits\RequestFactory;
 use Tests\Traits\UserDirector;
@@ -15,17 +16,25 @@ class PluginRemoveHookTest extends TestCase
     use AssertsHooks;
     use AgentDirector;
     use RequestFactory;
+    use RestoresAppRequest;
     use UserDirector;
 
     protected function setUp(): void
     {
         parent::setUp();
+        $this->snapshotAppRequest();
 
         // MapasBlame\Request::__construct lê $app->request->getIp(), e $app->request
         // é null por padrão em teste — Plugin.php:119 cria um `new Request()` a cada
         // remoção, então precisa estar montado antes de qualquer teste deste arquivo.
         $psr7 = $this->requestFactory->GET('site', 'index');
         $this->app->request = new CoreRequest($psr7, 'site', 'index', []);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreAppRequest();
+        parent::tearDown();
     }
 
     private function snapshotBlameRequestIds(): array

--- a/tests/src/PluginRequestHookAssemblyTest.php
+++ b/tests/src/PluginRequestHookAssemblyTest.php
@@ -66,7 +66,7 @@ class PluginRequestHookAssemblyTest extends TestCase
         );
     }
 
-    // ===== Cenário 6 (request.enable => false) =====
+    // ===== request.enable => false =====
     //
     // O guard `if ($plugin->config['request.enable'])` fica FORA da montagem da string
     // (Plugin.php:75), envolvendo tanto a montagem quanto o registro do hook — não há como

--- a/tests/src/PluginRequestHookAssemblyTest.php
+++ b/tests/src/PluginRequestHookAssemblyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Doubles\TestablePlugin;
+
+class PluginRequestHookAssemblyTest extends TestCase
+{
+    function testDefaultConfigAssemblesExpectedRouteString()
+    {
+        $plugin = new TestablePlugin();
+
+        $this->assertSame(
+            '<<GET|DELETE|PATCH|POST|PUT>>(<<*>>):before,-<<*>>(<<*>>.renewLock):before',
+            $plugin->buildRequestHookRoutes()
+        );
+    }
+
+    function testRequestTypesAreJoinedByPipeInsideVerbGroup()
+    {
+        $plugin = new TestablePlugin(['request.types' => ['POST', 'PUT']]);
+
+        $this->assertSame(
+            '<<POST|PUT>>(<<*>>):before,-<<*>>(<<*>>.renewLock):before',
+            $plugin->buildRequestHookRoutes()
+        );
+    }
+
+    function testEachRequestRouteGeneratesOnePositiveEntry()
+    {
+        $plugin = new TestablePlugin([
+            'request.routes' => ['rota.a', 'rota.b'],
+            'request.excludeRoutes' => [],
+        ]);
+
+        $this->assertSame(
+            '<<GET|DELETE|PATCH|POST|PUT>>(rota.a):before,<<GET|DELETE|PATCH|POST|PUT>>(rota.b):before',
+            $plugin->buildRequestHookRoutes()
+        );
+    }
+
+    function testEachExcludeRouteGeneratesOneNegativeEntry()
+    {
+        $plugin = new TestablePlugin([
+            'request.routes' => [],
+            'request.excludeRoutes' => ['rota.a.renewLock', 'rota.b.renewLock'],
+        ]);
+
+        $this->assertSame(
+            '-<<*>>(rota.a.renewLock):before,-<<*>>(rota.b.renewLock):before',
+            $plugin->buildRequestHookRoutes()
+        );
+    }
+
+    function testPositiveAndNegativeEntriesAreJoinedByComma()
+    {
+        $plugin = new TestablePlugin([
+            'request.routes' => ['rota.a'],
+            'request.excludeRoutes' => ['rota.a.renewLock'],
+        ]);
+
+        $this->assertSame(
+            '<<GET|DELETE|PATCH|POST|PUT>>(rota.a):before,-<<*>>(rota.a.renewLock):before',
+            $plugin->buildRequestHookRoutes()
+        );
+    }
+
+    // ===== Cenário 6 (request.enable => false) =====
+    //
+    // O guard `if ($plugin->config['request.enable'])` fica FORA da montagem da string
+    // (Plugin.php:75), envolvendo tanto a montagem quanto o registro do hook — não há como
+    // observá-lo chamando buildRequestHookRoutes() isoladamente, e testá-lo de verdade exigiria
+    // disparar `mapasculturais.run:before` numa instância real do Plugin (registrando um hook
+    // permanente na suíte, sem isolamento de processo). Skip deliberado: a preservação de
+    // `request.enable => false` na config já está coberta por
+    // PluginConfigTest::testConfigRequestEnableFalseIsPreserved.
+}

--- a/tests/src/RequestConstructTest.php
+++ b/tests/src/RequestConstructTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use MapasCulturais\Request as CoreRequest;
+use Sinergi\BrowserDetector\Browser;
+use Sinergi\BrowserDetector\Device;
+use Sinergi\BrowserDetector\Os;
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Doubles\TestableRequest;
+use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
+
+class RequestConstructTest extends TestCase
+{
+    use RequestFactory;
+    use UserDirector;
+
+    /**
+     * MapasBlame\Request::__construct lê $app->request->getIp(), então $app->request
+     * (null por padrão em teste) precisa estar montado antes de cada instanciação.
+     */
+    private function setAppRequestIp(?string $ip): void
+    {
+        $psr7 = $this->requestFactory->GET('site', 'index');
+
+        if ($ip !== null) {
+            $psr7 = $psr7->withAttribute('ip_address', $ip);
+        }
+
+        $this->app->request = new CoreRequest($psr7, 'site', 'index', []);
+    }
+
+    function testIdReceivesA13CharToken()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertSame(13, strlen($request->id));
+    }
+
+    function testTwoConsecutiveRequestsHaveDistinctIds()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $a = new TestableRequest();
+        $b = new TestableRequest();
+
+        $this->assertNotSame($a->id, $b->id);
+    }
+
+    function testEmptyMetadataArrayBecomesEmptyStdClass()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest([]);
+
+        $this->assertEquals(new \stdClass(), $request->metadata);
+    }
+
+    function testAssociativeMetadataArrayBecomesStdClassWithSameKeysAndValues()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest(['foo' => 'bar', 'baz' => 1]);
+
+        $this->assertEquals((object) ['foo' => 'bar', 'baz' => 1], $request->metadata);
+    }
+
+    function testIpComesFromRequestIpAddressAttributeWhenPresent()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertSame('203.0.113.10', $request->ip);
+    }
+
+    function testIpIsEmptyStringWhenIpAddressAttributeIsAbsent()
+    {
+        $this->setAppRequestIp(null);
+
+        $request = new TestableRequest();
+
+        $this->assertSame('', $request->ip);
+    }
+
+    function testUserAgentComesFromServerSuperglobalWhenSet()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $previous = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        $_SERVER['HTTP_USER_AGENT'] = 'MapasBlameTest-Agent/1.0';
+
+        try {
+            $request = new TestableRequest();
+
+            $this->assertSame('MapasBlameTest-Agent/1.0', $request->userAgent);
+        } finally {
+            if ($previous === null) {
+                unset($_SERVER['HTTP_USER_AGENT']);
+            } else {
+                $_SERVER['HTTP_USER_AGENT'] = $previous;
+            }
+        }
+    }
+
+    function testUserAgentIsEmptyStringWhenServerSuperglobalIsAbsent()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $hadKey = array_key_exists('HTTP_USER_AGENT', $_SERVER);
+        $previous = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        unset($_SERVER['HTTP_USER_AGENT']);
+
+        try {
+            $request = new TestableRequest();
+
+            $this->assertSame('', $request->userAgent);
+        } finally {
+            if ($hadKey) {
+                $_SERVER['HTTP_USER_AGENT'] = $previous;
+            }
+        }
+    }
+
+    function testSessionIdMatchesPhpSessionId()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertSame(session_id(), $request->sessionId);
+    }
+
+    function testUserIdIsLoggedInUserId()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $user = $this->userDirector->createUser();
+        $this->login($user);
+
+        $request = new TestableRequest();
+
+        $this->assertSame($user->id, $request->userId);
+    }
+
+    function testUserIdIsZeroForGuest()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        // setUp() já faz logout(); usuário atual é GuestUser (id === 0).
+        $request = new TestableRequest();
+
+        $this->assertSame(0, $request->userId);
+    }
+
+    function testBrowserOsDeviceAreSinergiInstances()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertInstanceOf(Browser::class, $request->browser);
+        $this->assertInstanceOf(Os::class, $request->os);
+        $this->assertInstanceOf(Device::class, $request->device);
+    }
+
+    function testIsNewIsTrueRightAfterConstruction()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertTrue($request->isNew());
+    }
+
+    function testConnIsEntityManagerConnection()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertSame($this->app->em->getConnection(), $request->conn());
+    }
+
+    function testConstructorWithoutArgumentDefaultsToEmptyMetadata()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+
+        $this->assertEquals(new \stdClass(), $request->metadata);
+    }
+}

--- a/tests/src/RequestConstructTest.php
+++ b/tests/src/RequestConstructTest.php
@@ -8,13 +8,27 @@ use Sinergi\BrowserDetector\Device;
 use Sinergi\BrowserDetector\Os;
 use Tests\Abstract\TestCase;
 use Tests\MapasBlame\Doubles\TestableRequest;
+use Tests\MapasBlame\Traits\RestoresAppRequest;
 use Tests\Traits\RequestFactory;
 use Tests\Traits\UserDirector;
 
 class RequestConstructTest extends TestCase
 {
     use RequestFactory;
+    use RestoresAppRequest;
     use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotAppRequest();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreAppRequest();
+        parent::tearDown();
+    }
 
     /**
      * MapasBlame\Request::__construct lê $app->request->getIp(), então $app->request

--- a/tests/src/RequestHookEffectTest.php
+++ b/tests/src/RequestHookEffectTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\MapasBlame;
 
+use Laminas\Diactoros\ServerRequest;
 use Tests\Abstract\TestCase;
 use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
 
 /**
  * Efeito do hook de request (Plugin.php:88-110). Todos os cenários vivem em UM ÚNICO teste,
@@ -23,6 +25,7 @@ use Tests\Traits\RequestFactory;
 class RequestHookEffectTest extends TestCase
 {
     use RequestFactory;
+    use UserDirector;
 
     private function snapshotBlameRequestIds(): array
     {
@@ -142,6 +145,20 @@ class RequestHookEffectTest extends TestCase
             $this->assertArrayHasKey($method, $metadata, "metadata deveria ter a chave {$method}");
             $this->assertSame([], $metadata[$method], "metadata[{$method}] deveria descartar o corpo da request (default de logData.{$method})");
         }
+
+        // ===== Rotas /api não geram nenhum log de request =====
+        // 'API' está comentado em request.types (Plugin.php:16) e o core só dispara hooks
+        // API(controller.action):before para essas rotas — nunca GET(...)/POST(...) (core
+        // Controller.php:305-308) — então o hook de log de request nunca chega a rodar aqui,
+        // mesmo com um dispatch real e bem-sucedido (200, admin autenticado).
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+        $beforeApi = $this->snapshotBlameRequestIds();
+        $apiRequest = new ServerRequest(method: 'GET', uri: '/api/blame/find');
+        $this->app->reset();
+        $this->app->run($apiRequest, false);
+        $afterApi = $this->snapshotBlameRequestIds();
+        $this->assertSame($beforeApi, $afterApi, 'Uma rota /api não deveria gerar um novo blame_request');
 
         // ===== Ação *.renewLock é excluída do log de request =====
         $beforeRenewLock = $this->snapshotBlameRequestIds();

--- a/tests/src/RequestHookEffectTest.php
+++ b/tests/src/RequestHookEffectTest.php
@@ -54,6 +54,11 @@ class RequestHookEffectTest extends TestCase
         );
     }
 
+    private function countAllBlameLogs(): int
+    {
+        return (int) $this->app->em->getConnection()->fetchScalar('SELECT count(*) FROM blame_log');
+    }
+
     /**
      * Dispara um hit real via $app->run() contra uma rota casada e retorna o ID do
      * ÚNICO blame_request novo que aparece — falha se não for exatamente 1 novo ID.
@@ -140,6 +145,12 @@ class RequestHookEffectTest extends TestCase
 
         // ===== Ação *.renewLock é excluída do log de request =====
         $beforeRenewLock = $this->snapshotBlameRequestIds();
+        // A esta altura do teste já existem vários holders acumulados (um por hit anterior),
+        // todos com Request não-nulo — só medir blame_request não basta: se a exclusão fosse
+        // removida da produção, os disparos ainda reusariam esses Requests existentes e
+        // inseririam só em blame_log (Plugin.php:92), nunca um blame_request novo. Por isso
+        // medimos os dois lados.
+        $beforeBlameLogCount = $this->countAllBlameLogs();
         // Dispara diretamente o nome de hook que uma ação real "*.renewLock" produziria
         // (Controller.php:308,332) — testa o mecanismo de exclusão do App\Hooks
         // (Plugin.php:18, `<<*>>.renewLock`) sem depender de uma entidade/rota real. Reusa o
@@ -147,7 +158,9 @@ class RequestHookEffectTest extends TestCase
         $context = (object) ['method' => 'POST', 'id' => 'agent', 'action' => 'renewLock'];
         $this->app->applyHookBoundTo($context, 'POST(agent.renewLock):before', []);
         $afterRenewLock = $this->snapshotBlameRequestIds();
+        $afterBlameLogCount = $this->countAllBlameLogs();
 
         $this->assertSame($beforeRenewLock, $afterRenewLock, 'Uma ação *.renewLock não deveria gerar um novo blame_request');
+        $this->assertSame($beforeBlameLogCount, $afterBlameLogCount, 'Uma ação *.renewLock não deveria gerar nenhum blame_log, nem reusando um Request existente');
     }
 }

--- a/tests/src/RequestHookEffectTest.php
+++ b/tests/src/RequestHookEffectTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use Tests\Abstract\TestCase;
+use Tests\Traits\RequestFactory;
+
+/**
+ * Efeito do hook de request (Plugin.php:88-110). Todos os cenários vivem em UM ÚNICO teste,
+ * sequencialmente, de propósito: MapasCulturais\Plugin registra o listener de log de request
+ * em `mapasculturais.run:before`, disparado só por $app->run() — e esse listener NÃO é
+ * idempotente: cada disparo cria um holder novo e registra MAIS UM listener no padrão de
+ * rotas montado (os antigos nunca são removidos). Em produção isso é inofensivo (1 processo
+ * PHP = 1 $app->run()). No processo de teste compartilhado, se dois MÉTODOS de teste
+ * diferentes cada um chamasse $app->run() (cada um com sua própria transação, com rollback em
+ * tearDown()), o holder do primeiro sobrevive (é um objeto PHP, não estado de banco) e, ao
+ * disparar de novo no segundo método, tenta inserir em blame_log com uma FK para o
+ * blame_request que o rollback do primeiro método já desfez — violação de FK que aborta a
+ * transação inteira. Por isso: um único método, uma única transação sem rollback no meio — os
+ * holders acumulados ao longo do teste continuam válidos porque nada é desfeito entre os
+ * passos.
+ */
+class RequestHookEffectTest extends TestCase
+{
+    use RequestFactory;
+
+    private function snapshotBlameRequestIds(): array
+    {
+        return $this->app->em->getConnection()->fetchColumn('SELECT id FROM blame_request');
+    }
+
+    private function withRequestUri(string $uri, callable $callback)
+    {
+        $hadKey = array_key_exists('REQUEST_URI', $_SERVER);
+        $previous = $_SERVER['REQUEST_URI'] ?? null;
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadKey) {
+                $_SERVER['REQUEST_URI'] = $previous;
+            } else {
+                unset($_SERVER['REQUEST_URI']);
+            }
+        }
+    }
+
+    private function fetchBlameLogs(string $requestId): array
+    {
+        return $this->app->em->getConnection()->fetchAll(
+            'SELECT * FROM blame_log WHERE request_id = ? ORDER BY id',
+            [$requestId]
+        );
+    }
+
+    /**
+     * Dispara um hit real via $app->run() contra uma rota casada e retorna o ID do
+     * ÚNICO blame_request novo que aparece — falha se não for exatamente 1 novo ID.
+     */
+    private function hitMatchedRouteAndGetNewRequestId($request, string $requestUri): string
+    {
+        $before = $this->snapshotBlameRequestIds();
+
+        $this->withRequestUri($requestUri, function () use ($request) {
+            $this->app->reset();
+            $this->app->run($request, false);
+        });
+
+        $after = $this->snapshotBlameRequestIds();
+        $new = array_values(array_diff($after, $before));
+
+        $this->assertCount(1, $new, 'Esperava exatamente 1 novo blame_request após o hit');
+
+        return $new[0];
+    }
+
+    function testRequestHookEffect()
+    {
+        // ===== Um hit numa rota casada gera 1 blame_request + 1 blame_log =====
+        $requestA = $this->requestFactory->GET('site', 'index');
+        $idA = $this->hitMatchedRouteAndGetNewRequestId($requestA, '/site/index');
+        $this->assertCount(1, $this->fetchBlameLogs($idA));
+
+        // ===== action no formato "{method} {request_uri} ({id}.{action})" =====
+        $logsA = $this->fetchBlameLogs($idA);
+        $this->assertSame('GET /site/index (site.index)', $logsA[0]['action']);
+
+        // ===== GET não adiciona chave de escrita ao metadata (só URL + GET) =====
+        $metadataA = json_decode($logsA[0]['metadata'], true);
+        $this->assertEqualsCanonicalizing(['URL', 'GET'], array_keys($metadataA));
+
+        // ===== Reuso do holder: 2º disparo na MESMA request usa o mesmo Request =====
+        $afterFirstHit = $this->snapshotBlameRequestIds();
+        // App::controller() é singleton — reaproveita a MESMA instância que processou o
+        // dispatch acima, com method/id/action já setados por Controller::callAction. Sem
+        // novo $app->run(), nenhum holder novo é criado: o disparo manual abaixo reusa o
+        // holder recém-criado pelo hit de cima.
+        $controller = $this->app->controller('site');
+        $this->withRequestUri('/site/index', function () use ($controller) {
+            $this->app->applyHookBoundTo(
+                $controller,
+                "{$controller->method}({$controller->id}.{$controller->action}):before",
+                []
+            );
+        });
+        $afterSecondFiring = $this->snapshotBlameRequestIds();
+
+        $this->assertSame($afterFirstHit, $afterSecondFiring, 'Um segundo disparo na mesma request não deveria criar um novo blame_request');
+        $this->assertCount(2, $this->fetchBlameLogs($idA), 'O segundo disparo deveria reusar o Request e adicionar um segundo blame_log');
+
+        // ===== metadata sempre inclui as chaves URL e GET =====
+        $requestB = $this->requestFactory->GET('site', 'index', [], ['foo' => 'bar']);
+        $idB = $this->hitMatchedRouteAndGetNewRequestId($requestB, '/site/index');
+        $logsB = $this->fetchBlameLogs($idB);
+        $metadataB = json_decode($logsB[0]['metadata'], true);
+        $this->assertArrayHasKey('URL', $metadataB);
+        $this->assertArrayHasKey('GET', $metadataB);
+
+        // ===== Verbo de escrita adiciona metadata[$method] =====
+        // 'site.clearCache' é ALL_clearCache() — aceita qualquer verbo HTTP e não exige
+        // entidade/permissão para disparar o hook :before (só age se o usuário for
+        // superAdmin, o que não é necessário aqui). RequestFactory não constrói PUT, então
+        // cobrimos POST/PATCH/DELETE.
+        foreach (['POST', 'PATCH', 'DELETE'] as $method) {
+            $request = $this->requestFactory->{$method}('site', 'clearCache');
+            $id = $this->hitMatchedRouteAndGetNewRequestId($request, '/site/clearCache');
+            $logs = $this->fetchBlameLogs($id);
+            $metadata = json_decode($logs[0]['metadata'], true);
+            $this->assertArrayHasKey($method, $metadata, "metadata deveria ter a chave {$method}");
+        }
+
+        // ===== Ação *.renewLock é excluída do log de request =====
+        $beforeRenewLock = $this->snapshotBlameRequestIds();
+        // Dispara diretamente o nome de hook que uma ação real "*.renewLock" produziria
+        // (Controller.php:308,332) — testa o mecanismo de exclusão do App\Hooks
+        // (Plugin.php:18, `<<*>>.renewLock`) sem depender de uma entidade/rota real. Reusa o
+        // registro já feito pelos hits acima, nesta mesma execução.
+        $context = (object) ['method' => 'POST', 'id' => 'agent', 'action' => 'renewLock'];
+        $this->app->applyHookBoundTo($context, 'POST(agent.renewLock):before', []);
+        $afterRenewLock = $this->snapshotBlameRequestIds();
+
+        $this->assertSame($beforeRenewLock, $afterRenewLock, 'Uma ação *.renewLock não deveria gerar um novo blame_request');
+    }
+}

--- a/tests/src/RequestHookEffectTest.php
+++ b/tests/src/RequestHookEffectTest.php
@@ -4,6 +4,7 @@ namespace Tests\MapasBlame;
 
 use Laminas\Diactoros\ServerRequest;
 use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Traits\RestoresHookRegistry;
 use Tests\Traits\RequestFactory;
 use Tests\Traits\UserDirector;
 
@@ -20,12 +21,27 @@ use Tests\Traits\UserDirector;
  * blame_request que o rollback do primeiro método já desfez — violação de FK que aborta a
  * transação inteira. Por isso: um único método, uma única transação sem rollback no meio — os
  * holders acumulados ao longo do teste continuam válidos porque nada é desfeito entre os
- * passos.
+ * passos. O tearDown() restaura o registro de hooks ao estado anterior ao teste, para que os
+ * listeners registrados aqui não vazem para outros arquivos que rodam depois no mesmo
+ * processo.
  */
 class RequestHookEffectTest extends TestCase
 {
     use RequestFactory;
+    use RestoresHookRegistry;
     use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotHookRegistry();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreHookRegistry();
+        parent::tearDown();
+    }
 
     private function snapshotBlameRequestIds(): array
     {

--- a/tests/src/RequestHookEffectTest.php
+++ b/tests/src/RequestHookEffectTest.php
@@ -109,25 +109,33 @@ class RequestHookEffectTest extends TestCase
         $this->assertSame($afterFirstHit, $afterSecondFiring, 'Um segundo disparo na mesma request não deveria criar um novo blame_request');
         $this->assertCount(2, $this->fetchBlameLogs($idA), 'O segundo disparo deveria reusar o Request e adicionar um segundo blame_log');
 
-        // ===== metadata sempre inclui as chaves URL e GET =====
+        // ===== metadata sempre inclui as chaves URL e GET, com o valor capturado verbatim =====
         $requestB = $this->requestFactory->GET('site', 'index', [], ['foo' => 'bar']);
         $idB = $this->hitMatchedRouteAndGetNewRequestId($requestB, '/site/index');
         $logsB = $this->fetchBlameLogs($idB);
         $metadataB = json_decode($logsB[0]['metadata'], true);
         $this->assertArrayHasKey('URL', $metadataB);
         $this->assertArrayHasKey('GET', $metadataB);
+        // logData.URL/GET default são a closure identidade (Plugin.php:19-24) — os valores
+        // devem ser exatamente urlData/getData do controller, não só as chaves presentes.
+        // 'site.index' não tem parâmetros de URL, então urlData é vazio.
+        $this->assertSame([], $metadataB['URL']);
+        $this->assertSame(['foo' => 'bar'], $metadataB['GET']);
 
-        // ===== Verbo de escrita adiciona metadata[$method] =====
+        // ===== Verbo de escrita adiciona metadata[$method] — e o valor descarta o corpo =====
         // 'site.clearCache' é ALL_clearCache() — aceita qualquer verbo HTTP e não exige
         // entidade/permissão para disparar o hook :before (só age se o usuário for
         // superAdmin, o que não é necessário aqui). RequestFactory não constrói PUT, então
-        // cobrimos POST/PATCH/DELETE.
+        // cobrimos POST/PATCH/DELETE. O payload não-vazio abaixo existe para provar que o
+        // corpo É descartado (logData.POST default retorna [], Plugin.php:25-27) — a decisão
+        // de privacidade central do plugin (nunca persistir senha/dado sensível em blame_log).
         foreach (['POST', 'PATCH', 'DELETE'] as $method) {
-            $request = $this->requestFactory->{$method}('site', 'clearCache');
+            $request = $this->requestFactory->{$method}('site', 'clearCache', payload: ['password' => 'segredo']);
             $id = $this->hitMatchedRouteAndGetNewRequestId($request, '/site/clearCache');
             $logs = $this->fetchBlameLogs($id);
             $metadata = json_decode($logs[0]['metadata'], true);
             $this->assertArrayHasKey($method, $metadata, "metadata deveria ter a chave {$method}");
+            $this->assertSame([], $metadata[$method], "metadata[{$method}] deveria descartar o corpo da request (default de logData.{$method})");
         }
 
         // ===== Ação *.renewLock é excluída do log de request =====

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -357,7 +357,7 @@ class RequestPersistenceTest extends TestCase
 
     /**
      * Byte nulo embutido numa string UTF-8 válida (não confundir com UTF-8 inválido, coberto
-     * no teste seguinte): `json_encode()` escapa `\0` como ` ` (JSON válido) — o round-trip
+     * no teste seguinte): `json_encode()` escapa `\0` como `\u0000` (JSON válido) — o round-trip
      * preserva o byte intacto. `Request::log()` (Request.php:69-75) não trata esse caso, só
      * passa `$metadata` verbatim para `json_encode()`.
      */

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -251,6 +251,28 @@ class RequestPersistenceTest extends TestCase
 
     // ===== log() =====
 
+    /**
+     * `log()` (Request.php:65-77) só chama `save()` se `$this->isNew` — um `save()` explícito
+     * antes já deixa `isNew` `false` (`testSaveFlipsIsNewToFalse`), então o `log()` seguinte não
+     * tenta inserir `blame_request` de novo (o que violaria a PK, como em
+     * `testCallingSaveTwiceViolatesPrimaryKeyConstraint`), só grava o `blame_log`.
+     */
+    function testExplicitSaveFollowedByLogDoesNotDuplicateBlameRequest()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->save();
+        $request->log('ACTION', []);
+
+        $count = $this->app->em->getConnection()->fetchScalar(
+            'SELECT count(*) FROM blame_request WHERE id = ?',
+            [$request->id]
+        );
+        $this->assertEquals(1, $count);
+        $this->assertSame(1, $this->countBlameLogs($request->id));
+    }
+
     function testFirstLogOnNewRequestInsertsBlameRequestAndBlameLog()
     {
         $this->setAppRequestIp('203.0.113.10');

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use MapasCulturais\Request as CoreRequest;
+use Tests\Abstract\TestCase;
+use Tests\MapasBlame\Doubles\TestableRequest;
+use Tests\Traits\RequestFactory;
+
+class RequestPersistenceTest extends TestCase
+{
+    use RequestFactory;
+
+    private function setAppRequestIp(string $ip): void
+    {
+        $psr7 = $this->requestFactory->GET('site', 'index')->withAttribute('ip_address', $ip);
+
+        $this->app->request = new CoreRequest($psr7, 'site', 'index', []);
+    }
+
+    private function fetchBlameRequest(string $id): ?array
+    {
+        return $this->app->em->getConnection()->fetchAssoc('SELECT * FROM blame_request WHERE id = ?', [$id]);
+    }
+
+    private function fetchBlameLogs(string $requestId): array
+    {
+        return $this->app->em->getConnection()->fetchAll(
+            'SELECT * FROM blame_log WHERE request_id = ? ORDER BY id',
+            [$requestId]
+        );
+    }
+
+    private function countBlameLogs(string $requestId): int
+    {
+        return count($this->fetchBlameLogs($requestId));
+    }
+
+    /**
+     * Executa $callback com $_SERVER['HTTP_USER_AGENT'] definido, sempre restaurando o valor
+     * anterior ao final — evita vazar a mutação do superglobal para os testes seguintes
+     * (a suíte roda sem isolamento de processo).
+     */
+    private function withUserAgent(string $userAgent, callable $callback)
+    {
+        $hadKey = array_key_exists('HTTP_USER_AGENT', $_SERVER);
+        $previous = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+
+        try {
+            return $callback();
+        } finally {
+            if ($hadKey) {
+                $_SERVER['HTTP_USER_AGENT'] = $previous;
+            } else {
+                unset($_SERVER['HTTP_USER_AGENT']);
+            }
+        }
+    }
+
+    // ===== save() =====
+
+    function testSaveInsertsOneRowIntoBlameRequest()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = $this->withUserAgent('MapasBlameTest-Agent/1.0', function () {
+            $request = new TestableRequest();
+            $request->save();
+            return $request;
+        });
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertNotNull($row);
+    }
+
+    function testSavePersistsAllElevenColumns()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = $this->withUserAgent('MapasBlameTest-Agent/1.0', function () {
+            $request = new TestableRequest();
+            $request->save();
+            return $request;
+        });
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        foreach (['id', 'ip', 'session_id', 'user_id', 'metadata', 'user_agent',
+                  'user_browser_name', 'user_browser_version', 'user_os', 'user_device', 'created_at'] as $column) {
+            $this->assertArrayHasKey($column, $row, "Coluna {$column} deveria existir em blame_request");
+        }
+    }
+
+    function testSavePersistsMetadataAsJsonEncodedObject()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest(['foo' => 'bar']);
+        $request->save();
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertSame(json_encode($request->metadata), $row['metadata']);
+    }
+
+    function testSavePersistsBrowserOsDeviceFromSinergiGetters()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $chromeUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+        $request = $this->withUserAgent($chromeUserAgent, function () {
+            $request = new TestableRequest();
+            $request->save();
+            return $request;
+        });
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertSame($request->browser->getName(), $row['user_browser_name']);
+        $this->assertSame($request->browser->getVersion(), $row['user_browser_version']);
+        $this->assertSame($request->os->getName(), $row['user_os']);
+        $this->assertSame($request->device->getName(), $row['user_device']);
+    }
+
+    function testSavePersistsCreatedAtInExpectedFormat()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->save();
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $row['created_at']);
+    }
+
+    function testSaveFlipsIsNewToFalse()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $this->assertTrue($request->isNew());
+
+        $request->save();
+
+        $this->assertFalse($request->isNew());
+    }
+
+    function testSaveCalledDirectlyInsertsNothingIntoBlameLog()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->save();
+
+        $this->assertSame(0, $this->countBlameLogs($request->id));
+    }
+
+    // ===== log() =====
+
+    function testFirstLogOnNewRequestInsertsBlameRequestAndBlameLog()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', []);
+
+        $this->assertNotNull($this->fetchBlameRequest($request->id));
+        $this->assertSame(1, $this->countBlameLogs($request->id));
+    }
+
+    function testSecondLogOnSameObjectDoesNotDuplicateBlameRequest()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION 1', []);
+        $request->log('ACTION 2', []);
+
+        $this->assertSame(2, $this->countBlameLogs($request->id));
+
+        $count = $this->app->em->getConnection()->fetchScalar(
+            'SELECT count(*) FROM blame_request WHERE id = ?',
+            [$request->id]
+        );
+        $this->assertEquals(1, $count);
+    }
+
+    function testIsNewIsFalseAfterFirstLog()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', []);
+
+        $this->assertFalse($request->isNew());
+    }
+
+    function testNCallsToLogProduceOneRequestAndNLogs()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION 1', []);
+        $request->log('ACTION 2', []);
+        $request->log('ACTION 3', []);
+
+        $count = $this->app->em->getConnection()->fetchScalar(
+            'SELECT count(*) FROM blame_request WHERE id = ?',
+            [$request->id]
+        );
+        $this->assertEquals(1, $count);
+        $this->assertSame(3, $this->countBlameLogs($request->id));
+    }
+
+    function testBlameLogRequestIdMatchesRequestId()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', []);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame($request->id, $logs[0]['request_id']);
+    }
+
+    function testActionIsPersistedVerbatim()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('GET /painel/blame (blame.index)', []);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame('GET /painel/blame (blame.index)', $logs[0]['action']);
+    }
+
+    function testLogMetadataIsPersistedAsJsonEncodedSecondArgument()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', ['GET' => ['q' => 'busca']]);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame(json_encode(['GET' => ['q' => 'busca']]), $logs[0]['metadata']);
+    }
+
+    function testLogCreatedAtInExpectedFormat()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', []);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $logs[0]['created_at']);
+    }
+
+    function testLogWithEmptyMetadataArrayPersistsWithoutError()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', []);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame('[]', $logs[0]['metadata']);
+    }
+
+    // ===== Edge cases de dados =====
+
+    function testMetadataWithAccentedCharactersSurvivesRoundTrip()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', ['nome' => 'inscrição do usuário']);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame(['nome' => 'inscrição do usuário'], json_decode($logs[0]['metadata'], true));
+    }
+
+    function testMetadataWithNestedArraysIsSerializedCorrectly()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $nested = ['GET' => ['filtros' => ['a', 'b'], 'paginacao' => ['page' => 2]]];
+
+        $request = new TestableRequest();
+        $request->log('ACTION', $nested);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame($nested, json_decode($logs[0]['metadata'], true));
+    }
+}

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -5,13 +5,27 @@ namespace Tests\MapasBlame;
 use MapasCulturais\Request as CoreRequest;
 use Tests\Abstract\TestCase;
 use Tests\MapasBlame\Doubles\TestableRequest;
+use Tests\MapasBlame\Traits\RestoresAppRequest;
 use Tests\Traits\RequestFactory;
 use Tests\Traits\UserDirector;
 
 class RequestPersistenceTest extends TestCase
 {
     use RequestFactory;
+    use RestoresAppRequest;
     use UserDirector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->snapshotAppRequest();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreAppRequest();
+        parent::tearDown();
+    }
 
     private function setAppRequestIp(string $ip): void
     {

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -171,6 +171,13 @@ class RequestPersistenceTest extends TestCase
         $this->assertSame(json_encode($request->metadata), $row['metadata']);
     }
 
+    /**
+     * Literais travados (não recomputados a partir do próprio getter Sinergi, o que só
+     * provaria round-trip contra si mesmo): para o Chrome/Windows UA acima, o
+     * `Sinergi\BrowserDetector` resolve `browser` = "Chrome", `browser version` = "120.0.0.0",
+     * `os` = "Windows", `device` = "unknown" (nenhum modelo de dispositivo reconhecido para
+     * esse UA desktop) — valor observado, verificado empiricamente.
+     */
     function testSavePersistsBrowserOsDeviceFromSinergiGetters()
     {
         $this->setAppRequestIp('203.0.113.10');
@@ -184,10 +191,10 @@ class RequestPersistenceTest extends TestCase
 
         $row = $this->fetchBlameRequest($request->id);
 
-        $this->assertSame($request->browser->getName(), $row['user_browser_name']);
-        $this->assertSame($request->browser->getVersion(), $row['user_browser_version']);
-        $this->assertSame($request->os->getName(), $row['user_os']);
-        $this->assertSame($request->device->getName(), $row['user_device']);
+        $this->assertSame('Chrome', $row['user_browser_name']);
+        $this->assertSame('120.0.0.0', $row['user_browser_version']);
+        $this->assertSame('Windows', $row['user_os']);
+        $this->assertSame('unknown', $row['user_device']);
     }
 
     function testSavePersistsCreatedAtInExpectedFormat()

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -373,4 +373,31 @@ class RequestPersistenceTest extends TestCase
         $this->assertSame(['valor' => "antes\0depois"], json_decode($logs[0]['metadata'], true));
     }
 
+    /**
+     * `Request::log()` (Request.php:69-75) chama `json_encode($metadata)` sem
+     * `JSON_INVALID_UTF8_SUBSTITUTE`/`JSON_THROW_ON_ERROR` — bytes que não formam UTF-8 válido
+     * (ex.: `\xB1` solto) fazem `json_encode()` retornar `false` **silenciosamente** (sem lançar
+     * exceção em si). Mas a coluna `metadata` é `JSON NOT NULL` no Postgres (db-updates.php:20,
+     * 41), não `text` — `$conn->insert()` com o valor `false` (convertido para string vazia
+     * pelo driver PDO) falha no banco com `SQLSTATE[22P02]: invalid input syntax for type json`
+     * ("The input string ended unexpectedly"), propagada como
+     * `Doctrine\DBAL\Exception\DriverException` não capturada por `Request::log()`.
+     * Comportamento observado: bytes inválidos de UTF-8 em qualquer valor logado (ex.: um
+     * parâmetro de query GET malformado) fariam o próprio log de auditoria da requisição falhar
+     * com uma exceção não tratada — dentro do listener de `mapasculturais.run:before`
+     * (Plugin.php:88-110), que roda como parte do processamento normal de qualquer rota casada,
+     * não isolado do restante da resposta.
+     */
+    function testMetadataWithInvalidUtf8BytesThrowsDriverExceptionOnInsert()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $this->assertFalse(json_encode(['valor' => "\xB1\x31"]), 'Pré-condição: confirma que essa sequência de bytes não é UTF-8 válido');
+
+        $request = new TestableRequest();
+
+        $this->expectException(\Doctrine\DBAL\Exception\DriverException::class);
+
+        $request->log('ACTION', ['valor' => "\xB1\x31"]);
+    }
 }

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -6,10 +6,12 @@ use MapasCulturais\Request as CoreRequest;
 use Tests\Abstract\TestCase;
 use Tests\MapasBlame\Doubles\TestableRequest;
 use Tests\Traits\RequestFactory;
+use Tests\Traits\UserDirector;
 
 class RequestPersistenceTest extends TestCase
 {
     use RequestFactory;
+    use UserDirector;
 
     private function setAppRequestIp(string $ip): void
     {
@@ -91,6 +93,56 @@ class RequestPersistenceTest extends TestCase
                   'user_browser_name', 'user_browser_version', 'user_os', 'user_device', 'created_at'] as $column) {
             $this->assertArrayHasKey($column, $row, "Coluna {$column} deveria existir em blame_request");
         }
+
+        // A existência da chave (acima) só prova o schema da tabela — um SELECT * sempre
+        // retorna todas as colunas, preenchidas ou não. As asserções abaixo travam que save()
+        // de fato grava o valor certo em cada uma.
+        $this->assertSame('203.0.113.10', $row['ip']);
+        $this->assertSame('MapasBlameTest-Agent/1.0', $row['user_agent']);
+    }
+
+    function testSavePersistsUserIdForLoggedInUser()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $user = $this->userDirector->createUser();
+        $this->login($user);
+
+        $request = new TestableRequest();
+        $request->save();
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertEquals($user->id, $row['user_id']);
+    }
+
+    function testSavePersistsZeroUserIdForGuest()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        // setUp() já faz logout(); usuário atual é GuestUser (id === 0).
+        $request = new TestableRequest();
+        $request->save();
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        $this->assertEquals(0, $row['user_id']);
+    }
+
+    function testSavePersistsSessionIdMatchingTheRequestProperty()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->save();
+
+        $row = $this->fetchBlameRequest($request->id);
+
+        // session_id é CHAR(32) no Postgres — valores mais curtos vêm de volta com padding
+        // de espaços à direita, daí o rtrim. Comparado contra a propriedade capturada na
+        // construção (não recomputado via session_id() aqui), mesmo padrão já usado para
+        // browser/os/device em testSavePersistsBrowserOsDeviceFromSinergiGetters.
+        $this->assertSame($request->sessionId, rtrim($row['session_id']));
     }
 
     function testSavePersistsMetadataAsJsonEncodedObject()

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -231,6 +231,24 @@ class RequestPersistenceTest extends TestCase
         $this->assertSame(0, $this->countBlameLogs($request->id));
     }
 
+    /**
+     * `save()` (Request.php:47-63) não checa `$this->isNew` antes de inserir — sempre monta o
+     * `INSERT` e o dispara. Chamar `save()` duas vezes no mesmo objeto tenta inserir a mesma
+     * `id` (PK de `blame_request`) de novo, violando a constraint. Comportamento observado, não
+     * assumido: `Doctrine\DBAL\Exception\UniqueConstraintViolationException`, não capturada.
+     */
+    function testCallingSaveTwiceViolatesPrimaryKeyConstraint()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->save();
+
+        $this->expectException(\Doctrine\DBAL\Exception\UniqueConstraintViolationException::class);
+
+        $request->save();
+    }
+
     // ===== log() =====
 
     function testFirstLogOnNewRequestInsertsBlameRequestAndBlameLog()

--- a/tests/src/RequestPersistenceTest.php
+++ b/tests/src/RequestPersistenceTest.php
@@ -354,4 +354,23 @@ class RequestPersistenceTest extends TestCase
 
         $this->assertSame($nested, json_decode($logs[0]['metadata'], true));
     }
+
+    /**
+     * Byte nulo embutido numa string UTF-8 válida (não confundir com UTF-8 inválido, coberto
+     * no teste seguinte): `json_encode()` escapa `\0` como ` ` (JSON válido) — o round-trip
+     * preserva o byte intacto. `Request::log()` (Request.php:69-75) não trata esse caso, só
+     * passa `$metadata` verbatim para `json_encode()`.
+     */
+    function testMetadataWithEmbeddedNullByteSurvivesRoundTrip()
+    {
+        $this->setAppRequestIp('203.0.113.10');
+
+        $request = new TestableRequest();
+        $request->log('ACTION', ['valor' => "antes\0depois"]);
+
+        $logs = $this->fetchBlameLogs($request->id);
+
+        $this->assertSame(['valor' => "antes\0depois"], json_decode($logs[0]['metadata'], true));
+    }
+
 }

--- a/tests/src/SmokeTest.php
+++ b/tests/src/SmokeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\MapasBlame;
+
+use MapasBlame\Controller;
+use MapasBlame\Plugin;
+use Tests\Abstract\TestCase;
+
+/**
+ * Smoke test de validação do add-on de testes do plugin MapasBlame
+ * (config + autoload + fixture, ver tests/docker-compose.yml deste plugin).
+ */
+class SmokeTest extends TestCase
+{
+    function testPluginIsActive()
+    {
+        $app = $this->app;
+
+        $this->assertArrayHasKey('MapasBlame', $app->plugins);
+        $this->assertInstanceOf(Plugin::class, $app->plugins['MapasBlame']);
+    }
+
+    function testBlameControllerIsRegistered()
+    {
+        $app = $this->app;
+
+        $this->assertInstanceOf(Controller::class, $app->controller('blame'));
+    }
+
+    function testBlameTablesExistAndPersist()
+    {
+        $conn = $this->app->em->getConnection();
+
+        $requestId = substr(md5(uniqid('', true)), 0, 13);
+
+        $conn->insert('blame_request', [
+            'id' => $requestId,
+            'ip' => '127.0.0.1',
+            'session_id' => str_repeat('a', 32),
+            'user_id' => 0,
+            'metadata' => json_encode([]),
+            'user_agent' => 'SmokeTest',
+            'user_browser_name' => 'SmokeTest',
+            'user_browser_version' => '1.0',
+            'user_os' => 'SmokeTest OS',
+            'user_device' => 'SmokeTest Device',
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+
+        $conn->insert('blame_log', [
+            'request_id' => $requestId,
+            'action' => 'SmokeTest ACTION',
+            'metadata' => json_encode([]),
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+
+        $request = $conn->fetchAssoc('SELECT * FROM blame_request WHERE id = ?', [$requestId]);
+        $log = $conn->fetchAssoc('SELECT * FROM blame_log WHERE request_id = ?', [$requestId]);
+
+        $this->assertNotNull($request, 'A linha inserida em blame_request deve ser lida de volta');
+        $this->assertNotNull($log, 'A linha inserida em blame_log deve ser lida de volta');
+        $this->assertSame('SmokeTest ACTION', $log['action']);
+    }
+}

--- a/tests/src/Traits/AssertsHooks.php
+++ b/tests/src/Traits/AssertsHooks.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\MapasBlame\Traits;
+
+use MapasCulturais\App;
+
+/**
+ * Helper para confirmar que um hook foi (ou não foi) disparado durante uma ação,
+ * sem depender de efeito colateral observável (sessão, banco, etc.) do próprio hook.
+ */
+trait AssertsHooks
+{
+    /**
+     * Registra um listener temporário no hook informado, executa $action() e confirma
+     * que o hook foi disparado pelo menos uma vez durante a execução.
+     */
+    protected function assertHookFired(string $hookName, callable $action, string $message = ''): void
+    {
+        $app = App::i();
+        $fired = false;
+
+        $app->hook($hookName, function () use (&$fired) {
+            $fired = true;
+        });
+
+        $action();
+
+        $this->assertTrue(
+            $fired,
+            $message !== '' ? $message : "Esperava que o hook '{$hookName}' fosse disparado, mas não foi."
+        );
+    }
+
+    /**
+     * Inverso de assertHookFired: confirma que o hook NÃO foi disparado durante a ação.
+     */
+    protected function assertHookNotFired(string $hookName, callable $action, string $message = ''): void
+    {
+        $app = App::i();
+        $fired = false;
+
+        $app->hook($hookName, function () use (&$fired) {
+            $fired = true;
+        });
+
+        $action();
+
+        $this->assertFalse(
+            $fired,
+            $message !== '' ? $message : "Esperava que o hook '{$hookName}' NÃO fosse disparado, mas foi."
+        );
+    }
+}

--- a/tests/src/Traits/AssertsHooks.php
+++ b/tests/src/Traits/AssertsHooks.php
@@ -11,8 +11,10 @@ use MapasCulturais\App;
 trait AssertsHooks
 {
     /**
-     * Registra um listener temporário no hook informado, executa $action() e confirma
-     * que o hook foi disparado pelo menos uma vez durante a execução.
+     * Registra um listener no hook informado, executa $action() e confirma que o hook foi
+     * disparado pelo menos uma vez durante a execução. O listener nunca é removido — fica
+     * registrado no App (singleton) pelo resto do processo, como qualquer outro registrado
+     * via $app->hook(); inofensivo aqui porque só seta uma flag local.
      */
     protected function assertHookFired(string $hookName, callable $action, string $message = ''): void
     {

--- a/tests/src/Traits/RestoresAppRequest.php
+++ b/tests/src/Traits/RestoresAppRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\MapasBlame\Traits;
+
+/**
+ * `App::reset()` (core/App.php:380-393), chamado por `TestCase::setUp()` antes de cada teste,
+ * não toca `$app->request` — um teste que atribui `$app->request` (para satisfazer
+ * `MapasBlame\Request::__construct`, que lê `$app->request->getIp()`) deixa esse valor vazando
+ * para o próximo teste que rodar no mesmo processo, mesmo em outro arquivo (a suíte roda sem
+ * isolamento de processo). Este trait tira um snapshot de `$app->request` antes da mutação e o
+ * restaura depois, do mesmo jeito que `RestoresHookRegistry` faz para o registro de hooks.
+ */
+trait RestoresAppRequest
+{
+    private $appRequestSnapshot;
+
+    protected function snapshotAppRequest(): void
+    {
+        $this->appRequestSnapshot = $this->app->request;
+    }
+
+    protected function restoreAppRequest(): void
+    {
+        $this->app->request = $this->appRequestSnapshot;
+    }
+}

--- a/tests/src/Traits/RestoresHookRegistry.php
+++ b/tests/src/Traits/RestoresHookRegistry.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\MapasBlame\Traits;
+
+/**
+ * Isola, entre métodos/arquivos de teste, os efeitos de $app->run() sobre o registro de
+ * hooks do App.
+ *
+ * O App é singleton e a suíte roda sem isolamento de processo — hooks registrados via
+ * $app->hook() (inclusive os que MapasBlame\Plugin::_init() registra a cada $app->run(), de
+ * forma não idempotente: cada disparo acrescenta MAIS UM listener permanente no padrão de
+ * rotas) sobrevivem para o resto do processo, a menos que algo os remova. Isso faz um
+ * arquivo de teste que despacha $app->run() vazar listeners para os testes seguintes,
+ * possivelmente com holders presos a linhas de banco já revertidas pelo rollback do teste.
+ *
+ * Este trait tira um snapshot do registro de hooks ANTES de cada teste e o restaura
+ * EXATAMENTE como estava depois — removendo só o que foi registrado durante o teste, sem
+ * tocar em nada que já existisse antes. Diferente de $app->clearHooks($nome), que remove por
+ * casamento de padrão contra o nome informado e pode atingir listeners legítimos de outros
+ * módulos/plugins que coincidentemente casem o mesmo nome.
+ */
+trait RestoresHookRegistry
+{
+    private $hookRegistrySnapshot;
+
+    protected function snapshotHookRegistry(): void
+    {
+        $this->hookRegistrySnapshot = [
+            'hooks' => $this->readHooksProperty('_hooks'),
+            'excludeHooks' => $this->readHooksProperty('_excludeHooks'),
+        ];
+    }
+
+    protected function restoreHookRegistry(): void
+    {
+        $this->writeHooksProperty('_hooks', $this->hookRegistrySnapshot['hooks']);
+        $this->writeHooksProperty('_excludeHooks', $this->hookRegistrySnapshot['excludeHooks']);
+        // getCallables() cacheia por nome firado; sem isso, um nome já consultado durante o
+        // teste continuaria retornando os callables removidos (ou deixando de retornar os
+        // restaurados) até que hook() registrasse algo novo e limpasse o cache sozinho.
+        $this->writeHooksProperty('_hookCache', []);
+    }
+
+    private function readHooksProperty(string $property)
+    {
+        $reflection = new \ReflectionProperty(\MapasCulturais\Hooks::class, $property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($this->app->hooks);
+    }
+
+    private function writeHooksProperty(string $property, $value): void
+    {
+        $reflection = new \ReflectionProperty(\MapasCulturais\Hooks::class, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->app->hooks, $value);
+    }
+}


### PR DESCRIPTION
# Suíte de testes do MapasBlame

## Cenário

O plugin MapasBlame não tinha nenhum teste. Este PR adiciona uma suíte que caracteriza o comportamento atual do plugin, para travar o que já existe e evitar regressão futura.

## Implementações

- Cobertura de `Plugin.php`, `Request.php` e `Controller.php`.
- Testes de hooks (log de request, remoção de entidade, autorização).
- Testes de API (`/api/blame/find`) e da superfície não-API do controller (`GET`/`DELETE /blame/single/{id}`).
- Casos de borda: metadata corrompida, `save()`/`log()` fora de ordem, vazamento de estado entre arquivos.

## Overview

- Arquivos de teste: 11
- Testes: 87
- Assertions: 159
- Todos passando, sem regressão
